### PR TITLE
Update golden JSON & integrated lumi

### DIFF
--- a/Common/test/Plotting/CMS_lumi.cpp
+++ b/Common/test/Plotting/CMS_lumi.cpp
@@ -26,7 +26,7 @@ float relExtraDY = 1.2;
 // ratio of "CMS" and extra text size
 float extraOverCmsTextSize  = 0.76;
 
-TString lumi_13TeV = "35.878 fb^{-1}";
+TString lumi_13TeV = "35.922 fb^{-1}";
 TString lumi_8TeV  = "19.7 fb^{-1}";
 TString lumi_7TeV  = "5.1 fb^{-1}";
 

--- a/Common/test/addWeightSamples.cpp
+++ b/Common/test/addWeightSamples.cpp
@@ -86,7 +86,7 @@ void addWeight(string FileName, float xsection, float lumi, std::string channel)
 
 void addWeightSamples()
 {
-  double lumi = 35878.;
+  double lumi = 35922.;
   std::string prefix = "/afs/cern.ch/work/m/maiqbal/private/aTGC/Samples_80X_Working/";
 
   //electron channel

--- a/Common/test/submit_jobs.py
+++ b/Common/test/submit_jobs.py
@@ -219,7 +219,7 @@ DataDictionaryElectronChannel = {
 	'data-RunH_ver2':'/SingleElectron/Run2016H-03Feb2017_ver2-v1/MINIAOD',
 	'data-RunH_ver3':'/SingleElectron/Run2016H-03Feb2017_ver3-v1/MINIAOD'}
 	
-MyJSON = "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/Final/Cert_271036-284044_13TeV_PromptReco_Collisions16_JSON.txt"
+MyJSON = "https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt"
 	
 
 submitJobs(MCBackgroundsSampleDictionary, SignalMCSampleDictionary, DataDictionaryElectronChannel, DataDictionaryMuonChannel, MyJSON,"271036-284044", True)


### PR DESCRIPTION
As per https://twiki.cern.ch/twiki/bin/view/CMS/PdmV2016Analysis#Re_reco_datasets

Note that this also changes the total integrated lumi to 35.922 /fb, as per https://hypernews.cern.ch/HyperNews/CMS/get/luminosity/688.html, so I have also updated the value in `addWeightSamples()` and in the plotting code, but I'm not sure if I've missed somewhere else the lumi is used?

BTW I double checked total lumi with brilcalc tool:

```
brilcalc lumi --normtag /afs/cern.ch/user/l/lumipro/public/Normtags/normtag_PHYSICS.json -i  /afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/ReReco/Final/Cert_271036-284044_13TeV_23Sep2016ReReco_Collisions16_JSON.txt
```

gives

```
#Summary:
+-------+------+--------+--------+-------------------+------------------+
| nfill | nrun | nls    | ncms   | totdelivered(/ub) | totrecorded(/ub) |
+-------+------+--------+--------+-------------------+------------------+
| 144   | 393  | 232259 | 232241 | 37461561951.880   | 35921908907.362  |
+-------+------+--------+--------+-------------------+------------------+
```