### PR TITLE
Update data MET

### DIFF
--- a/Common/analysis_ele.py
+++ b/Common/analysis_ele.py
@@ -84,6 +84,9 @@ process.jetSequence = cms.Sequence(process.fatJetsSequence +
                                             process.jetFilter+
                                            process.AK4JetsSequence )
 
+# Update the MET for latest JEC etc
+from aTGCsAnalysis.Common.MET_cff import doMetCorrections
+doMetCorrections(process, isData=True)
 
 process.treeDumper = cms.EDAnalyzer("TreeMaker",
                                     rho = cms.InputTag("fixedGridRhoFastjetAll"),
@@ -108,7 +111,7 @@ process.treeDumper = cms.EDAnalyzer("TreeMaker",
 process.DecayChannel = cms.EDAnalyzer("DecayChannelAnalyzer")
 
 # PATH
-process.analysis = cms.Path(process.NoiseFilters + process.BadChargedCandidateFilter  + process.BadPFMuonFilter + process.TriggerElectron +  process.METele +  process.egmGsfElectronIDSequence +  process.leptonSequence +   process.jetSequence  + process.treeDumper)
+process.analysis = cms.Path(process.NoiseFilters + process.BadChargedCandidateFilter  + process.BadPFMuonFilter + process.TriggerElectron + process.fullPatMetSequence + process.METele +  process.egmGsfElectronIDSequence +  process.leptonSequence +   process.jetSequence  + process.treeDumper)
 
 
 

--- a/Common/analysis_mu.py
+++ b/Common/analysis_mu.py
@@ -86,6 +86,10 @@ process.jetSequence = cms.Sequence(process.fatJetsSequence +
                                     process.jetFilter+
                                      process.AK4JetsSequence )
 
+# Update the MET for latest JEC etc
+from aTGCsAnalysis.Common.MET_cff import doMetCorrections
+doMetCorrections(process, isData=True)
+
 process.treeDumper = cms.EDAnalyzer("TreeMaker",
                                     rho = cms.InputTag("fixedGridRhoFastjetAll"),
                                     leptonicVSrc = cms.InputTag("Wtomunu"),
@@ -108,7 +112,7 @@ process.treeDumper = cms.EDAnalyzer("TreeMaker",
 process.DecayChannel = cms.EDAnalyzer("DecayChannelAnalyzer")
 
 # PATH
-process.analysis = cms.Path(process.NoiseFilters + process.BadChargedCandidateFilter  + process.BadPFMuonFilter  + process.TriggerMuon + process.METmu +  process.egmGsfElectronIDSequence +  process.leptonSequence +   process.jetSequence +  process.treeDumper)
+process.analysis = cms.Path(process.NoiseFilters + process.BadChargedCandidateFilter  + process.BadPFMuonFilter  + process.TriggerMuon + process.fullPatMetSequence + process.METmu +  process.egmGsfElectronIDSequence +  process.leptonSequence +  process.jetSequence +  process.treeDumper)
 
 process.source = cms.Source("PoolSource",
     secondaryFileNames = cms.untracked.vstring(),

--- a/Common/python/MET_cff.py
+++ b/Common/python/MET_cff.py
@@ -12,4 +12,12 @@ METmu = cms.EDFilter("PATMETSelector",
                          filter = cms.bool(True)
                          )
 
+from PhysicsTools.PatUtils.tools.runMETCorrectionsAndUncertainties import runMetCorAndUncFromMiniAOD
 
+def doMetCorrections(process, isData):
+    # If you only want to re-correct and get the proper uncertainties
+    # eg do Type-1 corrections due to new JEC
+    runMetCorAndUncFromMiniAOD(process, isData=isData)
+    # Update the main MET selectors
+    process.METmu.src = cms.InputTag("patPFMetT1")
+    process.METele.src = cms.InputTag("patPFMetT1")

--- a/README.md
+++ b/README.md
@@ -1,19 +1,22 @@
 aTGC Analysis
 ========
 
-```
+
 This is the analysis code for anomalous triple gauge couplings at 13 TeV using CMSSW framework.
 
 Setup Instructions
 ------------------
 
+```
 # Setup CMSSW
-cmsrel CMSSW_8_0_25
-cd CMSSW_8_0_25/src
+cmsrel CMSSW_8_0_28
+cd CMSSW_8_0_28/src
 cmsenv
 
+# Necessary for doing MET corrections, see https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETUncertaintyPrescription
+git cms-merge-topic -u cms-met:METRecipe_8020_for80Xintegration
+
 # Checkout aTGC analysis code
-git cms-merge-topic -u cms-met:CMSSW_8_0_X-METFilterUpdate
 git clone -b 80X git@github.com:muhammadansariqbal/aTGCsAnalysis.git
 
 # Compile
@@ -54,3 +57,4 @@ cd Plotting
 
 An example below makes plots in the ttbar control region in the electron channel with data, Monte-Carlo, signal and no systematics :
 ./draw --CR ttbar --channel ele --output ttbar_CR --input /afs/cern.ch/work/m/maiqbal/private/aTGC/Samples_80X_Working/ --withSignal --withMC --withData
+```

--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ cmsenv
 # Necessary for doing MET corrections, see https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETUncertaintyPrescription
 git cms-merge-topic -u cms-met:METRecipe_8020_for80Xintegration
 
+# HEEP electron ID, see https://twiki.cern.ch/twiki/bin/view/CMS/HEEPElectronIdentificationRun2
+# brings in HEEP V70 into VID:
+git cms-merge-topic Sam-Harper:HEEPV70VID_8010_ReducedCheckout
+# for other E/gamma IDs in VID if you wish to have them:
+git cms-merge-topic ikrav:egm_id_80X_v3
+# we need this for the mva weights which runs in VID regardless if you need it or not:
+mkdir -p ../external/slc6_amd64_gcc530/data/RecoEgamma/ElectronIdentification/ 
+# we need this for the mva weights which runs in VID regardless if you need it or not:
+git clone git@github.com:cms-data/RecoEgamma-ElectronIdentification ../external/slc6_amd64_gcc530/data/RecoEgamma/ElectronIdentification/data
+
 # Checkout aTGC analysis code
 git clone -b 80X git@github.com:muhammadansariqbal/aTGCsAnalysis.git
 

--- a/TreeMaker/plugins/TreeMaker.cc
+++ b/TreeMaker/plugins/TreeMaker.cc
@@ -247,6 +247,10 @@ TreeMaker::TreeMaker(const edm::ParameterSet& iConfig):
   BTagHelper_(iConfig.getParameter<std::string>("BtagEffFile"))
 {
 
+  if ((channel != "mu") && (channel != "el")) {
+    throw cms::Exception("InvalidValue") << "Invalid value for channel parameter, should be mu or el." << std::endl;
+  }
+
   // For PUPPI Correction
   edm::FileInPath puppiCorr("aTGCsAnalysis/TreeMaker/data/puppiCorrSummer16.root");
   TFile* file = TFile::Open( puppiCorr.fullPath().c_str(),"READ");
@@ -825,11 +829,7 @@ TreeMaker::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
       triggerWeightHLTEle27NoER  =  trigEle27NoER::turnOn(sc_et, sc_eta);
 
     }
-    else {
-      std::cerr << "Invalid channel used, use el or mu." << std::endl;
-      exit(0);
-    }
-     if (isMC){
+    if (isMC){
        Lepton.pt_LeptonEnUp = LeptonSystMap.at("LeptonEnUp").Pt();
        Lepton.pt_LeptonEnDown = LeptonSystMap.at("LeptonEnDown").Pt();
        Lepton.pt_LeptonResUp = LeptonSystMap.at("LeptonResUp").Pt();
@@ -857,7 +857,6 @@ TreeMaker::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
       LeptonSF_Up =  LeptonSF;
       LeptonSF_Down =  LeptonSF;
     }
-   else  throw cms::Exception("InvalidValue") << "Invalid channel, should be mu or el." << std::endl; 
    //leptonically decaying W
    if (leptonicVs -> size() > 0)
    {
@@ -976,10 +975,6 @@ TreeMaker::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
             MET_LeptonEnDown = metCand.shiftedPt( pat::MET::MuonEnDown, pat::MET::Type1) ;
           }
           
-          else {
-            std::cerr << "Invalid channel used, please use mu or el." << std::endl;
-            exit(0);
-          }  
           //MET phi uncertainties
           //METUncl
           MET_Phi_UnclEnUp = metCand.shiftedPhi( pat::MET::UnclusteredEnUp, pat::MET::Type1) ;
@@ -999,11 +994,7 @@ TreeMaker::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
             MET_Phi_LeptonEnUp = metCand.shiftedPhi( pat::MET::MuonEnUp, pat::MET::Type1) ;
             MET_Phi_LeptonEnDown = metCand.shiftedPhi( pat::MET::MuonEnDown, pat::MET::Type1) ;
         }
-         else {
-            std::cerr << "Invalid channel used, please use mu or el." << std::endl;
-           exit(0);
-          }  
-      } 
+      }
    }
    
     else


### PR DESCRIPTION
This updates MET in data to use the latest JEC, utilising the official MET tool.
Note, this involves (a) moving to CMSSW_8_0_28, (b) checking out an extra package - see README.md.

Only data has to be updated, since the MC MiniAOD was already created with the latest JEC and therefore doesn't need updating. (Unless a new set of JEC for MC get released, of course)

**NB** I haven't included the MET-phi corrections here, since we should check the plots first to see if they are needed.

**NB2** this also isn't the most efficient flow sequence of modules - the tool basically adds in every module. Running in unscheduled mode doesn't seem to stop this...

Useful links:
https://twiki.cern.ch/twiki/bin/view/CMS/MissingETUncertaintyPrescription
https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETRun2Corrections

I also update the README with the HEEP instructions.
