### PR TITLE
Update single top T-channel samples & other job improvements

### DIFF
--- a/Common/test/Plotting/draw.cpp
+++ b/Common/test/Plotting/draw.cpp
@@ -304,7 +304,8 @@ void draw(std::string channel, std::string region, std::string tag, string prefi
 	s.SetParameters("Single Top", MCSelection, kBlue);
  	s.SetFileNames(prefix + "tW-ch-top_" + channel + ".root");
  	s.SetFileNames(prefix + "tW-ch-antitop_" + channel + ".root");
- 	s.SetFileNames(prefix + "t-ch_" + channel + ".root");
+ 	s.SetFileNames(prefix + "t-ch-top_" + channel + ".root");
+ 	s.SetFileNames(prefix + "t-ch-antitop_" + channel + ".root");
  	s.SetFileNames(prefix + "s-ch_" + channel + ".root");
 	samples.push_back(s);
 	s.ReSet();

--- a/Common/test/addExtendedStats.sh
+++ b/Common/test/addExtendedStats.sh
@@ -14,7 +14,8 @@ hadd WJets_Ht1200To2500_mu.root $sourceDir"WJets_Ht1200To2500_mu.root" $sourceDi
 hadd WJets_Ht2500ToInf_mu.root $sourceDir"WJets_Ht2500ToInf_mu.root" $sourceDir"WJets_Ht2500ToInf-ext_mu.root"
 hadd WW_mu.root $sourceDir"WW_mu.root" $sourceDir"WW-ext_mu.root"
 echo "WZ";scp $sourceDir"WZ_mu.root" .
-hadd t-ch_mu.root $sourceDir"t-ch_mu.root" $sourceDir"t-ch-ext_mu.root"
+echo "t-top"; scp $sourceDir"t-ch-top_mu.root" .
+echo "t-antitop"; scp $sourceDir"t-ch-antitop_mu.root" .
 echo "s-channel";scp $sourceDir"s-ch_mu.root" .
 echo "tw-top";scp $sourceDir"tW-ch-top_mu.root" .
 echo "tw-antitop";scp $sourceDir"tW-ch-antitop_mu.root" .
@@ -35,7 +36,8 @@ hadd WJets_Ht1200To2500_ele.root $sourceDir"WJets_Ht1200To2500_ele.root" $source
 hadd WJets_Ht2500ToInf_ele.root $sourceDir"WJets_Ht2500ToInf_ele.root" $sourceDir"WJets_Ht2500ToInf-ext_ele.root"
 hadd WW_ele.root $sourceDir"WW_ele.root" $sourceDir"WW-ext_ele.root"
 echo "WZ";scp $sourceDir"WZ_ele.root" .
-hadd t-ch_ele.root $sourceDir"t-ch_ele.root" $sourceDir"t-ch-ext_ele.root"
+echo "t-top";scp $sourceDir"t-ch-top_ele.root" .
+echo "t-antitop";scp $sourceDir"t-ch-antitop_ele.root" .
 echo "s-channel";scp $sourceDir"s-ch_ele.root" .
 echo "tw-top";scp $sourceDir"tW-ch-top_ele.root" .
 echo "tw-antitop";scp $sourceDir"tW-ch-antitop_ele.root" .

--- a/Common/test/addExtendedStats.sh
+++ b/Common/test/addExtendedStats.sh
@@ -3,8 +3,10 @@
 
 sourceDir=../Samples_80X_date/
 
+cpCmd=scp
+
 echo "Processing Muon Channel"
-echo "ttbar";scp $sourceDir"ttbar_mu.root" .
+echo "ttbar";$cpCmd $sourceDir"ttbar_mu.root" .
 hadd WJets_Ht100To200_mu.root $sourceDir"WJets_Ht100To200_mu.root" $sourceDir"WJets_Ht100To200-ext1_mu.root" $sourceDir"WJets_Ht100To200-ext2_mu.root"
 hadd WJets_Ht200To400_mu.root $sourceDir"WJets_Ht200To400_mu.root" $sourceDir"WJets_Ht200To400-ext1_mu.root" $sourceDir"WJets_Ht200To400-ext2_mu.root"
 hadd WJets_Ht400To600_mu.root $sourceDir"WJets_Ht400To600_mu.root" $sourceDir"WJets_Ht400To600-ext_mu.root"
@@ -13,20 +15,20 @@ hadd WJets_Ht800To1200_mu.root $sourceDir"WJets_Ht800To1200_mu.root" $sourceDir"
 hadd WJets_Ht1200To2500_mu.root $sourceDir"WJets_Ht1200To2500_mu.root" $sourceDir"WJets_Ht1200To2500-ext_mu.root"
 hadd WJets_Ht2500ToInf_mu.root $sourceDir"WJets_Ht2500ToInf_mu.root" $sourceDir"WJets_Ht2500ToInf-ext_mu.root"
 hadd WW_mu.root $sourceDir"WW_mu.root" $sourceDir"WW-ext_mu.root"
-echo "WZ";scp $sourceDir"WZ_mu.root" .
-echo "t-top"; scp $sourceDir"t-ch-top_mu.root" .
-echo "t-antitop"; scp $sourceDir"t-ch-antitop_mu.root" .
-echo "s-channel";scp $sourceDir"s-ch_mu.root" .
-echo "tw-top";scp $sourceDir"tW-ch-top_mu.root" .
-echo "tw-antitop";scp $sourceDir"tW-ch-antitop_mu.root" .
-echo "WW-aTGC_MWW-600To800";scp $sourceDir"WW-aTGC_MWW-600To800_mu.root" .
-echo "WW-aTGC_MWW-800ToInf";scp $sourceDir"WW-aTGC_MWW-800ToInf_mu.root" .
-echo "WZ-aTGC_MWZ-600To800";scp $sourceDir"WZ-aTGC_MWZ-600To800_mu.root" .
-echo "WZ-aTGC_MWZ-800ToInf";scp $sourceDir"WZ-aTGC_MWZ-800ToInf_mu.root" .
+echo "WZ";$cpCmd $sourceDir"WZ_mu.root" .
+echo "t-top"; $cpCmd $sourceDir"t-ch-top_mu.root" .
+echo "t-antitop"; $cpCmd $sourceDir"t-ch-antitop_mu.root" .
+echo "s-channel";$cpCmd $sourceDir"s-ch_mu.root" .
+echo "tw-top";$cpCmd $sourceDir"tW-ch-top_mu.root" .
+echo "tw-antitop";$cpCmd $sourceDir"tW-ch-antitop_mu.root" .
+echo "WW-aTGC_MWW-600To800";$cpCmd $sourceDir"WW-aTGC_MWW-600To800_mu.root" .
+echo "WW-aTGC_MWW-800ToInf";$cpCmd $sourceDir"WW-aTGC_MWW-800ToInf_mu.root" .
+echo "WZ-aTGC_MWZ-600To800";$cpCmd $sourceDir"WZ-aTGC_MWZ-600To800_mu.root" .
+echo "WZ-aTGC_MWZ-800ToInf";$cpCmd $sourceDir"WZ-aTGC_MWZ-800ToInf_mu.root" .
 hadd data_mu.root $sourceDir"data-RunB_ver2_mu.root" $sourceDir"data-RunC_mu.root" $sourceDir"data-RunD_mu.root" $sourceDir"data-RunE_mu.root" $sourceDir"data-RunF_mu.root" $sourceDir"data-RunG_mu.root" $sourceDir"data-RunH_ver2_mu.root" $sourceDir"data-RunH_ver3_mu.root"
 
 echo "Processing Electron Channel"
-echo "ttbar";scp $sourceDir"ttbar_ele.root" .
+echo "ttbar";$cpCmd $sourceDir"ttbar_ele.root" .
 hadd WJets_Ht100To200_ele.root $sourceDir"WJets_Ht100To200_ele.root" $sourceDir"WJets_Ht100To200-ext1_ele.root" $sourceDir"WJets_Ht100To200-ext2_ele.root"
 hadd WJets_Ht200To400_ele.root $sourceDir"WJets_Ht200To400_ele.root" $sourceDir"WJets_Ht200To400-ext1_ele.root" $sourceDir"WJets_Ht200To400-ext2_ele.root"
 hadd WJets_Ht400To600_ele.root $sourceDir"WJets_Ht400To600_ele.root" $sourceDir"WJets_Ht400To600-ext_ele.root"
@@ -35,14 +37,14 @@ hadd WJets_Ht800To1200_ele.root $sourceDir"WJets_Ht800To1200_ele.root" $sourceDi
 hadd WJets_Ht1200To2500_ele.root $sourceDir"WJets_Ht1200To2500_ele.root" $sourceDir"WJets_Ht1200To2500-ext_ele.root"
 hadd WJets_Ht2500ToInf_ele.root $sourceDir"WJets_Ht2500ToInf_ele.root" $sourceDir"WJets_Ht2500ToInf-ext_ele.root"
 hadd WW_ele.root $sourceDir"WW_ele.root" $sourceDir"WW-ext_ele.root"
-echo "WZ";scp $sourceDir"WZ_ele.root" .
-echo "t-top";scp $sourceDir"t-ch-top_ele.root" .
-echo "t-antitop";scp $sourceDir"t-ch-antitop_ele.root" .
-echo "s-channel";scp $sourceDir"s-ch_ele.root" .
-echo "tw-top";scp $sourceDir"tW-ch-top_ele.root" .
-echo "tw-antitop";scp $sourceDir"tW-ch-antitop_ele.root" .
-echo "WW-aTGC_MWW-600To800";scp $sourceDir"WW-aTGC_MWW-600To800_ele.root" .
-echo "WW-aTGC_MWW-800ToInf";scp $sourceDir"WW-aTGC_MWW-800ToInf_ele.root" .
-echo "WZ-aTGC_MWZ-600To800";scp $sourceDir"WZ-aTGC_MWZ-600To800_ele.root" .
-echo "WZ-aTGC_MWZ-800ToInf";scp $sourceDir"WZ-aTGC_MWZ-800ToInf_ele.root" .
+echo "WZ";$cpCmd $sourceDir"WZ_ele.root" .
+echo "t-top";$cpCmd $sourceDir"t-ch-top_ele.root" .
+echo "t-antitop";$cpCmd $sourceDir"t-ch-antitop_ele.root" .
+echo "s-channel";$cpCmd $sourceDir"s-ch_ele.root" .
+echo "tw-top";$cpCmd $sourceDir"tW-ch-top_ele.root" .
+echo "tw-antitop";$cpCmd $sourceDir"tW-ch-antitop_ele.root" .
+echo "WW-aTGC_MWW-600To800";$cpCmd $sourceDir"WW-aTGC_MWW-600To800_ele.root" .
+echo "WW-aTGC_MWW-800ToInf";$cpCmd $sourceDir"WW-aTGC_MWW-800ToInf_ele.root" .
+echo "WZ-aTGC_MWZ-600To800";$cpCmd $sourceDir"WZ-aTGC_MWZ-600To800_ele.root" .
+echo "WZ-aTGC_MWZ-800ToInf";$cpCmd $sourceDir"WZ-aTGC_MWZ-800ToInf_ele.root" .
 hadd data_ele.root $sourceDir"data-RunB_ver2_ele.root" $sourceDir"data-RunC_ele.root" $sourceDir"data-RunD_ele.root" $sourceDir"data-RunE_ele.root" $sourceDir"data-RunF_ele.root" $sourceDir"data-RunG_ele.root" $sourceDir"data-RunH_ver2_ele.root" $sourceDir"data-RunH_ver3_ele.root"

--- a/Common/test/addWeightSamples.cpp
+++ b/Common/test/addWeightSamples.cpp
@@ -126,7 +126,8 @@ void addWeightSamples()
   addWeight(prefix + "WW_mu.root", 49.997, lumi, "");
   addWeight(prefix + "WZ_mu.root", 11.46, lumi, "");
   addWeight(prefix + "s-ch_mu.root", 10.32*0.33, lumi,"");
-  addWeight(prefix + "t-ch_mu.root", 216.99*0.33, lumi,""); 
+  addWeight(prefix + "t-ch-top_mu.root", 136.02, lumi,""); 
+  addWeight(prefix + "t-ch-antitop_mu.root", 80.95, lumi,""); 
   addWeight(prefix + "tW-ch-top_mu.root", 35.6, lumi,""); 
   addWeight(prefix + "tW-ch-antitop_mu.root", 35.6, lumi,""); 
   addWeight(prefix + "WJets_Ht100To200_mu.root", 1345.0*1.21, lumi,""); 

--- a/Common/test/addWeightSamples.cpp
+++ b/Common/test/addWeightSamples.cpp
@@ -103,7 +103,8 @@ void addWeightSamples()
   /*addWeight(prefix + "WW_ele.root", 49.997, lumi, "ele");
   addWeight(prefix + "WZ_ele.root", 11.46, lumi, "ele");
   addWeight(prefix + "s-ch_ele.root", 10.32*0.33, lumi, "ele");
-  addWeight(prefix + "t-ch_ele.root", 216.99*0.33, lumi, "ele");
+  addWeight(prefix + "t-ch-top_ele.root", 136.02, lumi, "ele");
+  addWeight(prefix + "t-ch-antitop_ele.root", 80.95, lumi, "ele");
   addWeight(prefix + "tW-ch-top_ele.root", 35.6, lumi, "ele");
   addWeight(prefix + "tW-ch-antitop_ele.root", 35.6, lumi, "ele");
   addWeight(prefix + "WJets_Ht100To200_ele.root", 1345.0*1.21, lumi, "ele");

--- a/Common/test/retrieve_jobs.py
+++ b/Common/test/retrieve_jobs.py
@@ -75,8 +75,8 @@ TaskDictionaryNameUnordered = [
 
 	("WZ","WZ"),
 
-	("SingleTop-t-channel","t-ch"),
-	("SingleTop-t-channel-ext","t-ch-ext"),
+	("SingleTop-t-channel-top","t-ch-top"),
+	("SingleTop-t-channel-antitop","t-ch-antitop"),
 
 	("SingleTop-s-channel","s-ch"),
 
@@ -108,5 +108,5 @@ def Retrieval(feature, outDir):
 		RetrieveTask(TaskName + "_mu_" + feature, OutName + "_mu", outDir)
 #		RetrieveTask(TaskName + "_ele_" + feature, OutName + "_ele", outDir )
 
-
-Retrieval("my_feature", "/afs/cern.ch/work/m/maiqbal/private/aTGC/Samples_80X_Working/" )
+if __name__ == '__main__':
+	Retrieval("my_feature", "/afs/cern.ch/work/m/maiqbal/private/aTGC/Samples_80X_Working/" )

--- a/Common/test/submit_jobs.py
+++ b/Common/test/submit_jobs.py
@@ -34,75 +34,94 @@ def DefineNJobs(sample):
 	return NFilesPerJob
 
 
-def createConfigFile(processName, channel, isMC, isSignal, runBtoF=True):
-	if not os.path.exists("analysisConfigs"):
-		os.makedirs("analysisConfigs")
-	BTagEfficiencyPattern = "BtagEffFile = cms.string(\"\"),\n"
-	VTagSFPattern = "VTagSF = cms.double(1.03)"
-	ConfigFileName = ""
-   	if isSignal and isMC :
-   		shutil.copy("../analysis_" + channel + "_signal.py", "analysisConfigs")
-   		ConfigFileName = "analysisConfigs/analysis_" + channel + "_signal.py"
-   	elif  processName == "WZ":
-   		shutil.copy("../analysis_" + channel + "_MC.py", "analysisConfigs/analysis_" + channel + "_" + processName + ".py")
-   		ConfigFileName = "analysisConfigs/analysis_" + channel + "_" + processName + ".py"
-   		configFile = open("../analysis_" + channel + "_MC.py")
-   		outFile = open("analysisConfigs/analysis_" + channel + "_" + processName + ".py", "w+")
-   		for line in configFile:
-   			if BTagEfficiencyPattern in line :
-   				replaceWith = "BtagEffFile = cms.string(\"aTGCsAnalysis/TreeMaker/data/eff_" + processName + "_" + channel + ".root\"),\n"
-   				outFile.write(line.replace(BTagEfficiencyPattern, replaceWith ))
-   			else :
-   				outFile.write(line)
-   	elif "ttbar" in processName:
-   		shutil.copy("../analysis_" + channel + "_MC.py", "analysisConfigs/analysis_" + channel + "_" + processName + ".py")
-   		ConfigFileName = "analysisConfigs/analysis_" + channel + "_" + processName + ".py"
-   		configFile = open("../analysis_" + channel + "_MC.py")
-   		outFile = open("analysisConfigs/analysis_" + channel + "_" + processName + ".py", "w+")
-   		for line in configFile:
-   			if BTagEfficiencyPattern in line :
-   				replaceWith = "BtagEffFile = cms.string(\"aTGCsAnalysis/TreeMaker/data/eff_ttbar_" + channel + ".root\"),\n"
-   				outFile.write(line.replace(BTagEfficiencyPattern, replaceWith ))
-   			else :
-   				outFile.write(line)
-   	# don't apply V-tagging scale factor for W+jets or single top t-channel and s-channel
-   	elif "WJets" in processName or "SingleTop-t-channel" in  processName or "SingleTop-s-channel" in processName:
-   		print processName
-   		shutil.copy("../analysis_" + channel + "_MC.py", "analysisConfigs/analysis_" + channel + "_" + processName + ".py")
-   		ConfigFileName = "analysisConfigs/analysis_" + channel + "_" + processName + ".py"
-   		configFile = open("../analysis_" + channel + "_MC.py")
-   		outFile = open("analysisConfigs/analysis_" + channel + "_" + processName + ".py", "w+")
-   		for line in configFile:
-   			if VTagSFPattern in line :
-   				replaceWith = "VTagSF = cms.double(1.0)"
-   				outFile.write(line.replace(VTagSFPattern, replaceWith ))
-   			else :
-   				outFile.write(line)
+def copy_customise_analysis_config(template, output_filename, btag_eff_file=None, vtag_sf=None, runBtoF=None):
+	"""Create a CMSSW config file by copying a template, and customising it.
 
-   	elif isMC :
-   		shutil.copy("../analysis_" + channel + "_MC.py", "analysisConfigs")
-   		ConfigFileName = "analysisConfigs/analysis_" + channel + "_MC.py"
-   	elif not isMC :
-   		# DATA
-   		original_config = "../analysis_" + channel + ".py"
-   		ConfigFileName = "analysisConfigs/analysis_"+channel+"_" + processName + ".py"
-   		shutil.copy(original_config, ConfigFileName)
-   		# specific edits for Runs B-F vs G-H
-   		if not runBtoF:
-			with open(original_config) as inFile, open(ConfigFileName, "w+") as outFile:
-				for line in inFile:
-					if "runBtoF=True" in line:
-						outFile.write(line.replace("runBtoF=True", "runBtoF=False"))
-					else:
-						outFile.write(line)
-   	else :
-   		raise ValueError('This should not happen!')
-   	return os.path.abspath(ConfigFileName)
+	Optional values for BtagEffFile, VTagSF, and runBtoF (in met corrections).
+	Setting any of these to None will use whatever is in the template config.
+
+	For btag_eff_file, the str should be relative to aTGCsAnalysis/TreeMaker/data/
+	"""
+	if not any((btag_eff_file, vtag_sf, (runBtoF is True or runBtoF is False))):
+		shutil.copy(template, output_filename)
+	else:
+		BTagEfficiencyPattern = "BtagEffFile = cms.string("
+		VTagSFPattern = "VTagSF = cms.double("
+		RunPattern = "runBtoF=True"  # hmm be careful with this...what if it changes in the template?
+		with open(template) as configFile, open(output_filename, "w") as outFile:
+			for line in configFile:
+				if btag_eff_file and BTagEfficiencyPattern in line :
+					replaceWith = "                                    BtagEffFile = cms.string(\"aTGCsAnalysis/TreeMaker/data/%s\"),\n" % btag_eff_file
+					outFile.write(replaceWith)
+				elif vtag_sf and VTagSFPattern in line:
+					replaceWith = "                                    VTagSF = cms.double(%f)" % vtag_sf
+					outFile.write(replaceWith)
+				elif (runBtoF is True or runBtoF is False) and RunPattern in line:
+					outFile.write(line.replace(RunPattern, "runBtoF=%s" % runBtoF))
+				else :
+					outFile.write(line)
+
+
+def createConfigFile(processName, channel, isMC, isSignal, runBtoF=True):
+	config_outdir = "analysisConfigs_test"
+	if not os.path.exists(config_outdir):
+		os.makedirs(config_outdir)
+
+	# Some common settings
+	TemplateFileName = "../analysis_" + channel + "_MC.py"
+	ConfigFileName = config_outdir + "/analysis_" + channel + "_" + processName + "_MC.py"
+	VTagSF = 1.03
+	NoVTagSF = 1.0
+	btag_file = "eff_" + processName + "_" + channel + ".root"
+
+	if isSignal and isMC :
+		ConfigFileName = config_outdir + "/analysis_" + channel + "_signal.py"
+		copy_customise_analysis_config("../analysis_" + channel + "_signal.py", ConfigFileName)
+
+	elif "WZ" in processName:
+		copy_customise_analysis_config(TemplateFileName, ConfigFileName, btag_eff_file=btag_file, vtag_sf=VTagSF)
+
+	elif "WW" in processName:
+		copy_customise_analysis_config(TemplateFileName, ConfigFileName, vtag_sf=VTagSF)
+
+	elif "ttbar" in processName:
+		copy_customise_analysis_config(TemplateFileName, ConfigFileName, btag_eff_file=btag_file, vtag_sf=VTagSF)
+
+	elif "WJets" in processName:
+		copy_customise_analysis_config(TemplateFileName, ConfigFileName, vtag_sf=NoVTagSF)
+
+	elif "SingleTop-t-channel-top" in processName:
+		copy_customise_analysis_config(TemplateFileName, ConfigFileName, vtag_sf=NoVTagSF)
+
+	elif "SingleTop-t-channel-antitop" in processName:
+		copy_customise_analysis_config(TemplateFileName, ConfigFileName, vtag_sf=NoVTagSF)
+
+	elif "SingleTop-tW-channel-top" in processName:
+		copy_customise_analysis_config(TemplateFileName, ConfigFileName, vtag_sf=NoVTagSF)
+
+	elif "SingleTop-tW-channel-antitop" in processName:
+		copy_customise_analysis_config(TemplateFileName, ConfigFileName, vtag_sf=NoVTagSF)
+
+	elif "SingleTop-s-channel" in processName:
+		copy_customise_analysis_config(TemplateFileName, ConfigFileName, vtag_sf=NoVTagSF)
+
+	elif isMC :
+		copy_customise_analysis_config(TemplateFileName, ConfigFileName, btag_eff_file=None, vtag_sf=NoVTagSF)
+
+	elif not isMC :
+		# DATA
+		ConfigFileName = config_outdir + "/analysis_" + channel + "_" + processName + ".py"
+		copy_customise_analysis_config("../analysis_" + channel + ".py", ConfigFileName, runBtoF=runBtoF)
+
+	else :
+		raise ValueError('This should not happen!')
+
+	return os.path.abspath(ConfigFileName)
 
 
 def createFileForJob(processName, channel, sampleName, feature, configFileName, outDir, YourJSONFile, RunRange, isMC, isSignal, wantToSubmit=False, fileName='template.txt'):
 	if not os.path.exists(outDir):
-    		os.makedirs(outDir)
+		os.makedirs(outDir)
 
 	patternFeature = "$FEATURE$"
 	patternProcessName = "$PROCESS$"
@@ -159,24 +178,24 @@ parser.add_option('-p', '--Feature', dest="Feature", default='my_feature')
 
 
 def submitJobs(MCBackgroundsSampleDictionary, SignalMCSampleDictionary, DataDictionaryElectronChannel, DataDictionaryMuonChannel, JSONFile, YourRunRange,wantToSubmit=False):
-#	for key in MCBackgroundsSampleDictionary:
-#		ConfigFileName = createConfigFile(key, "mu", True, False)
-#		print key, " ", ConfigFileName
-#		createFileForJob(key, "mu", MCBackgroundsSampleDictionary[key], options.Feature, ConfigFileName,  "crabConfigs",  JSONFile, YourRunRange, True, False, wantToSubmit)
-#		ConfigFileName = createConfigFile(key, "ele", True, False)
-#		createFileForJob(key, "ele", MCBackgroundsSampleDictionary[key], options.Feature, ConfigFileName,  "crabConfigs",  JSONFile, YourRunRange, True, False, wantToSubmit)
-#	for key in SignalMCSampleDictionary:
-#		ConfigFileName = createConfigFile(key, "mu", True, True)
-#		createFileForJob(key, "mu", SignalMCSampleDictionary[key], options.Feature, ConfigFileName,  "crabConfigs",  JSONFile, YourRunRange, True, True, wantToSubmit)
-#		ConfigFileName = createConfigFile(key, "ele", True, True)
-#		createFileForJob(key, "ele", SignalMCSampleDictionary[key], options.Feature, ConfigFileName, "crabConfigs", JSONFile, YourRunRange, True, True, wantToSubmit)
-#	for key in DataDictionaryElectronChannel:
-#		runBtoF = not ("RunG" in key or "RunH" in key)
-#		ConfigFileName = createConfigFile(key, "ele", False, False, runBtoF)
-#		createFileForJob(key, "ele", DataDictionaryElectronChannel[key], options.Feature, ConfigFileName,  "crabConfigs",  JSONFile, YourRunRange, False, True, wantToSubmit)
+	# for key in MCBackgroundsSampleDictionary:
+	# 	ConfigFileName = createConfigFile(key, "mu", isMC=True, isSignal=False)
+	# 	print key, " ", ConfigFileName
+	# 	createFileForJob(key, "mu", MCBackgroundsSampleDictionary[key], options.Feature, ConfigFileName,  "crabConfigs",  JSONFile, YourRunRange, True, False, wantToSubmit)
+	# 	ConfigFileName = createConfigFile(key, "ele", isMC=True, isSignal=False)
+	# 	createFileForJob(key, "ele", MCBackgroundsSampleDictionary[key], options.Feature, ConfigFileName,  "crabConfigs",  JSONFile, YourRunRange, True, False, wantToSubmit)
+	# for key in SignalMCSampleDictionary:
+	# 	ConfigFileName = createConfigFile(key, "mu", isMC=True, isSignal=True)
+	# 	createFileForJob(key, "mu", SignalMCSampleDictionary[key], options.Feature, ConfigFileName,  "crabConfigs",  JSONFile, YourRunRange, True, True, wantToSubmit)
+	# 	ConfigFileName = createConfigFile(key, "ele", isMC=True, isSignal=True)
+	# 	createFileForJob(key, "ele", SignalMCSampleDictionary[key], options.Feature, ConfigFileName, "crabConfigs", JSONFile, YourRunRange, True, True, wantToSubmit)
+	# for key in DataDictionaryElectronChannel:
+	# 	runBtoF = not ("RunG" in key or "RunH" in key)
+	# 	ConfigFileName = createConfigFile(key, "ele", isMC=False, isSignal=False, runBtoF=runBtoF)
+	# 	createFileForJob(key, "ele", DataDictionaryElectronChannel[key], options.Feature, ConfigFileName,  "crabConfigs",  JSONFile, YourRunRange, False, True, wantToSubmit)
 	for key in DataDictionaryMuonChannel:
 		runBtoF = not ("RunG" in key or "RunH" in key)
-		ConfigFileName = createConfigFile(key, "mu", False, False, runBtoF)
+		ConfigFileName = createConfigFile(key, "mu", isMC=False, isSignal=False, runBtoF=runBtoF)
 		createFileForJob(key, "mu", DataDictionaryMuonChannel[key], options.Feature, ConfigFileName,  "crabConfigs",  JSONFile, YourRunRange, False, True, wantToSubmit)
 
 MCBackgroundsSampleDictionaryUnordered =[

--- a/Common/test/submit_jobs.py
+++ b/Common/test/submit_jobs.py
@@ -7,13 +7,23 @@ import shutil
 import subprocess
 import collections
 
+
+# Cached num files per dataset, to avoid unnecessary das_client calls
+CACHED_DATASETS = {}
+
+
 def DefineNJobs(sample): 
-	output = subprocess.check_output(['das_client.py', '--query', "file dataset=" + sample + " | count(file.name)"])
-	for line in output.splitlines():
-		if "count(file.name)=" in line :
-			replacedline = line.replace("count(file.name)=","")
-	N = int(replacedline)
-	
+	N = 0
+	if sample in CACHED_DATASETS:
+		N = CACHED_DATASETS[sample]
+	else:
+		output = subprocess.check_output(['das_client.py', '--query', "file dataset=" + sample + " | count(file.name)"])
+		for line in output.splitlines():
+			if "count(file.name)=" in line :
+				replacedline = line.replace("count(file.name)=","")
+		N = int(replacedline)
+		CACHED_DATASETS[sample] = N
+
 	minNFiles = 100
 	if N < minNFiles :
 		NFilesPerJob = 1

--- a/Common/test/submit_jobs.py
+++ b/Common/test/submit_jobs.py
@@ -145,8 +145,11 @@ def createFileForJob(processName, channel, sampleName, feature, configFileName, 
 			tempFile.write( line)
 	tempFile.close()
 	if wantToSubmit :
-		os.system("crab submit -c " + os.path.dirname(os.path.abspath(__file__)) + "/" + outDir + "/"  + processName + "-" + channel + ".py")
-		print "\033[0;40;32mtask:", processName + "-" + channel, "was submitted!\033[0m"
+		rtrn = subprocess.call("crab submit -c " + os.path.dirname(os.path.abspath(__file__)) + "/" + outDir + "/"  + processName + "-" + channel + ".py", shell=True)
+		if rtrn == 0:
+			print "\033[0;40;32mtask:", processName + "-" + channel, "was submitted!\033[0m"
+		else:
+			print "\033[0;40;31mtask:", processName + "-" + channel, "was not submitted!\033[0m"
 	return;
 
 

--- a/Common/test/submit_jobs.py
+++ b/Common/test/submit_jobs.py
@@ -8,18 +8,18 @@ import subprocess
 import collections
 
 def DefineNJobs(sample): 
-	ps = subprocess.Popen(['das_client.py', '--query', "file dataset=" + sample + " | count(file.name)"], stdout=subprocess.PIPE)
-	output = ps.communicate()[0]
+	output = subprocess.check_output(['das_client.py', '--query', "file dataset=" + sample + " | count(file.name)"])
 	for line in output.splitlines():
 		if "count(file.name)=" in line :
 			replacedline = line.replace("count(file.name)=","")
 	N = int(replacedline)
 	
-	if N < 100 :
+	minNFiles = 100
+	if N < minNFiles :
 		NFilesPerJob = 1
 	else :
 		# let's roughly assume that number of files is ~1000 in the worst case
-		NFilesPerJob = int(N/100)
+		NFilesPerJob = int(N/minNFiles)
 	print "N of files per job : " , sample , " " , NFilesPerJob	
 	return NFilesPerJob
 

--- a/Common/test/submit_jobs.py
+++ b/Common/test/submit_jobs.py
@@ -8,7 +8,7 @@ import subprocess
 import collections
 
 def DefineNJobs(sample): 
-	ps = subprocess.Popen(['./das_client.py', '--query', "file dataset=" + sample + " | count(file.name)"], stdout=subprocess.PIPE)
+	ps = subprocess.Popen(['das_client.py', '--query', "file dataset=" + sample + " | count(file.name)"], stdout=subprocess.PIPE)
 	output = ps.communicate()[0]
 	for line in output.splitlines():
 		if "count(file.name)=" in line :

--- a/Common/test/submit_jobs.py
+++ b/Common/test/submit_jobs.py
@@ -79,13 +79,13 @@ def createConfigFile(processName, channel, isMC, isSignal, runBtoF=True):
 		copy_customise_analysis_config("../analysis_" + channel + "_signal.py", ConfigFileName)
 
 	elif "WZ" in processName:
-		copy_customise_analysis_config(TemplateFileName, ConfigFileName, btag_eff_file=btag_file, vtag_sf=VTagSF)
+		copy_customise_analysis_config(TemplateFileName, ConfigFileName, btag_eff_file="eff_WZ_" + channel + ".root", vtag_sf=VTagSF)
 
 	elif "WW" in processName:
 		copy_customise_analysis_config(TemplateFileName, ConfigFileName, vtag_sf=VTagSF)
 
 	elif "ttbar" in processName:
-		copy_customise_analysis_config(TemplateFileName, ConfigFileName, btag_eff_file=btag_file, vtag_sf=VTagSF)
+		copy_customise_analysis_config(TemplateFileName, ConfigFileName, btag_eff_file="eff_ttbar_"+channel+".root", vtag_sf=VTagSF)
 
 	elif "WJets" in processName:
 		copy_customise_analysis_config(TemplateFileName, ConfigFileName, vtag_sf=NoVTagSF)

--- a/Common/test/submit_jobs.py
+++ b/Common/test/submit_jobs.py
@@ -197,8 +197,8 @@ MCBackgroundsSampleDictionaryUnordered =[
 
 	('WZ','/WZTo1L1Nu2Q_13TeV_amcatnloFXFX_madspin_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v3/MINIAODSIM'),
 
-	('SingleTop-t-channel','/ST_t-channel_4f_leptonDecays_13TeV-amcatnlo-herwigpp_TuneEE5C/RunIISpring16MiniAODv2-premix_withHLT_80X_mcRun2_asymptotic_v14-v1/MINIAODSIM'),
-	('SingleTop-t-channel-ext','/ST_t-channel_4f_leptonDecays_13TeV-amcatnlo-pythia8_TuneCUETP8M1/RunIISpring16MiniAODv2-premix_withHLT_80X_mcRun2_asymptotic_v14_ext1-v1/MINIAODSIM'),
+	('SingleTop-t-channel-top','/ST_t-channel_top_4f_inclusiveDecays_13TeV-powhegV2-madspin-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM'),
+	('SingleTop-t-channel-antitop','/ST_t-channel_antitop_4f_inclusiveDecays_13TeV-powhegV2-madspin-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM'),
 
 	('SingleTop-s-channel','/ST_s-channel_4f_leptonDecays_13TeV-amcatnlo-pythia8_TuneCUETP8M1/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM'),
 
@@ -244,4 +244,6 @@ SignalMCSampleDictionary=collections.OrderedDict(SignalMCSampleDictionaryUnorder
 DataDictionaryMuonChannel=collections.OrderedDict(DataDictionaryMuonChannelUnordered)
 DataDictionaryElectronChannel=collections.OrderedDict(DataDictionaryElectronChannelUnordered)
 
-submitJobs(MCBackgroundsSampleDictionary, SignalMCSampleDictionary, DataDictionaryElectronChannel, DataDictionaryMuonChannel, MyJSON,"271036-284044", True)
+if __name__ == "__main__":
+	submitJobs(MCBackgroundsSampleDictionary, SignalMCSampleDictionary, DataDictionaryElectronChannel, DataDictionaryMuonChannel, MyJSON,"271036-284044", True)
+

--- a/Common/test/submit_jobs.py
+++ b/Common/test/submit_jobs.py
@@ -97,16 +97,16 @@ def createConfigFile(processName, channel, isMC, isSignal, runBtoF=True):
 		copy_customise_analysis_config(TemplateFileName, ConfigFileName, vtag_sf=NoVTagSF)
 
 	elif "SingleTop-tW-channel-top" in processName:
-		copy_customise_analysis_config(TemplateFileName, ConfigFileName, vtag_sf=NoVTagSF)
+		copy_customise_analysis_config(TemplateFileName, ConfigFileName, vtag_sf=VTagSF)
 
 	elif "SingleTop-tW-channel-antitop" in processName:
-		copy_customise_analysis_config(TemplateFileName, ConfigFileName, vtag_sf=NoVTagSF)
+		copy_customise_analysis_config(TemplateFileName, ConfigFileName, vtag_sf=VTagSF)
 
 	elif "SingleTop-s-channel" in processName:
 		copy_customise_analysis_config(TemplateFileName, ConfigFileName, vtag_sf=NoVTagSF)
 
 	elif isMC :
-		copy_customise_analysis_config(TemplateFileName, ConfigFileName, btag_eff_file=None, vtag_sf=NoVTagSF)
+		copy_customise_analysis_config(TemplateFileName, ConfigFileName, btag_eff_file=None, vtag_sf=VTagSF)
 
 	elif not isMC :
 		# DATA


### PR DESCRIPTION
This PR does a few things:

- Adds in Summer16 single top T-channel samples, with separate samples for top and antitop. This replaces the old Spring16 samples (which had a mixture of Herwig & Pythia). Moving to these new samples doesn't appear to have much of a difference, but should be done anyway for consistency.

- Improvements to submit_jobs.py, namely simplifying the construction of sample-specific analysis configs. This makes it far easier to see what the specific VTagSF, BTag, etc settings were for each sample, and does all the file generation in one place. This is also in preparation for the new BTagging SF. I have not changed any of the sample-specific settings here, they should be exactly the same as before.

- Also cached das_client results to speed things up when we eventually move to both mu+ele channels (In theory one could use the `multiprocessing` module to do parallel job submission... let me know if you want this, I've done it before and can dig out the code)

- Handle das_client errors bit more clearly, rather than trying to carry on regardless

- In addExtendedStats.sh I've made the `scp` command a variable as I use cp :)

- Added a few `if __name__ == "__main__"`  to allow `import`-ing of bits of those scripts