### PR TITLE
Update/fix V jet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
-*.pyc
+*.d
+*.log
 *.o
-
+*.out
+*.pcm
+*.pdf
+*.pyc
+*.root
+*.so
+__init__.py
+crab_projects/

--- a/Common/python/goodJets_cff.py
+++ b/Common/python/goodJets_cff.py
@@ -10,7 +10,7 @@ from PhysicsTools.PatAlgos.producersLayer1.jetUpdater_cff import updatedPatJets
 
 patAK8JetCorrFactorsReapplyJEC = updatedPatJetCorrFactors.clone(
         src = cms.InputTag("slimmedJetsAK8"),
-        levels = ['L2Relative', 'L3Absolute'],  # no L1FastJet ?
+        levels = ['L1FastJet', 'L2Relative', 'L3Absolute'],
         payload = 'AK8PFchs'
         )
 

--- a/Common/test/Plotting/Plotter.cpp
+++ b/Common/test/Plotting/Plotter.cpp
@@ -861,8 +861,8 @@ void Plotter::Plotting(std::string OutPrefix_)
         	}
     }
     if(withMC){
-      data_dif_MCerr -> SetMaximum(2.);
-      data_dif_MCerr ->  SetMinimum(-2.);
+      data_dif_MCerr -> SetMaximum(.5);
+      data_dif_MCerr ->  SetMinimum(-.5);
       data_dif_MCerr -> GetYaxis() -> SetNdivisions(5);
       data_dif_MCerr -> GetYaxis() -> SetLabelSize(0.15);
       data_dif_MCerr -> GetXaxis() -> SetLabelSize(0.2);

--- a/Common/test/Plotting/draw.cpp
+++ b/Common/test/Plotting/draw.cpp
@@ -15,6 +15,16 @@ void draw(std::string channel, std::string region, std::string tag, string prefi
 	var.nBins=30;
 	variables.push_back(var);
 
+	var.VarName = "jet_tau21_PUPPI";
+	var.Title = "#tau_{21} PUPPI";
+	var.SetRange(0., 0.7);
+	variables.push_back(var);
+
+	var.VarName = "jet_tau32_PUPPI";
+	var.Title = "#tau_{32} PUPPI";
+	var.SetRange(0., 1.);
+	variables.push_back(var);
+
 	var.VarName = "jet_tau2tau1";
 	var.Title = "#tau_{21}";
 	var.SetRange(0., 0.7);
@@ -188,8 +198,8 @@ void draw(std::string channel, std::string region, std::string tag, string prefi
 	p.setLumi(35922., 1.);
 
 	
-	// string defaulCuts = "(jet_pt > 200. && jet_tau2tau1 < 0.6  && Mjpruned < 150. && Mjpruned > 40. && W_pt > 200.  && abs(deltaR_LeptonWJet) > pi/2. && abs(deltaPhi_WJetMet) > 2. && abs(deltaPhi_WJetWlep) > 2. && MWW > 900.";
-	string defaulCuts = "(jet_pt > 200. && jet_tau2tau1 < 0.55  && jet_mass_softdrop_PUPPI < 150. && jet_mass_softdrop_PUPPI > 40. && W_pt > 200.  && abs(deltaR_LeptonWJet) > pi/2. && abs(deltaPhi_WJetMet) > 2. && abs(deltaPhi_WJetWlep) > 2. && MWW > 900.";
+	// string defaulCuts = "(jet_pt > 200. && jet_tau21_PUPPI < 0.6  && Mjpruned < 150. && Mjpruned > 40. && W_pt > 200.  && abs(deltaR_LeptonWJet) > pi/2. && abs(deltaPhi_WJetMet) > 2. && abs(deltaPhi_WJetWlep) > 2. && MWW > 900.";
+	string defaulCuts = "(jet_pt > 200. && jet_tau21_PUPPI < 0.55  && jet_mass_softdrop_PUPPI < 150. && jet_mass_softdrop_PUPPI > 40. && W_pt > 200.  && abs(deltaR_LeptonWJet) > pi/2. && abs(deltaPhi_WJetMet) > 2. && abs(deltaPhi_WJetWlep) > 2. && MWW > 900.";
 	if (channel == "ele") defaulCuts += " && l_pt > 50. && pfMET > 80. )"; 
 	else if (channel == "mu") defaulCuts += " && l_pt > 50. && pfMET > 40. )"; 
 	else {
@@ -201,8 +211,8 @@ void draw(std::string channel, std::string region, std::string tag, string prefi
 	string addOnCutWjets = defaulCuts +  " * ( (jet_mass_softdrop_PUPPI  < 65. || jet_mass_softdrop_PUPPI > 105. ) && nbtag == 0) ";
         string addOnCutTtbar = defaulCuts +  " * (nbtag > 0 )";
 
-	// string signalRegion  ="(jet_pt > 200. && jet_tau2tau1 < 0.6  && Mjpruned < 105. && Mjpruned > 65. && W_pt > 200.  && abs(deltaR_LeptonWJet) > pi/2. && abs(deltaPhi_WJetMet) > 2. && abs(deltaPhi_WJetWlep) > 2. && MWW > 900. && nbtag == 0";
-	string signalRegion  ="(jet_pt > 200. && jet_tau2tau1 < 0.55  && jet_mass_softdrop_PUPPI < 105. && jet_mass_softdrop_PUPPI > 65. && W_pt > 200.  && abs(deltaR_LeptonWJet) > pi/2. && abs(deltaPhi_WJetMet) > 2. && abs(deltaPhi_WJetWlep) > 2. && MWW > 900. && nbtag == 0";
+	// string signalRegion  ="(jet_pt > 200. && jet_tau21_PUPPI < 0.6  && Mjpruned < 105. && Mjpruned > 65. && W_pt > 200.  && abs(deltaR_LeptonWJet) > pi/2. && abs(deltaPhi_WJetMet) > 2. && abs(deltaPhi_WJetWlep) > 2. && MWW > 900. && nbtag == 0";
+	string signalRegion  ="(jet_pt > 200. && jet_tau21_PUPPI < 0.55  && jet_mass_softdrop_PUPPI < 105. && jet_mass_softdrop_PUPPI > 65. && W_pt > 200.  && abs(deltaR_LeptonWJet) > pi/2. && abs(deltaPhi_WJetMet) > 2. && abs(deltaPhi_WJetWlep) > 2. && MWW > 900. && nbtag == 0";
 	if (channel == "ele") signalRegion += " && l_pt > 50. && pfMET > 80. )"; 
 	else if (channel == "mu") signalRegion += " && l_pt > 50. && pfMET > 40. )"; 
 	else {
@@ -210,8 +220,8 @@ void draw(std::string channel, std::string region, std::string tag, string prefi
 		exit(0);
 	}
 
-	// string TTBarEnrichedInclusive = "(jet_pt > 200.  &&  jet_tau2tau1 < 0.6  && Mjpruned < 200. && Mjpruned > 40. && W_pt > 200.  && abs(deltaR_LeptonWJet) > pi/2. && abs(deltaPhi_WJetMet) > 2. && abs(deltaPhi_WJetWlep) > 2. && MWW > 900. ";
-	string TTBarEnrichedInclusive = "(jet_pt > 200.  &&  jet_tau2tau1 < 0.55  && jet_mass_softdrop_PUPPI < 200. && jet_mass_softdrop_PUPPI > 40. && W_pt > 200.  && abs(deltaR_LeptonWJet) > pi/2. && abs(deltaPhi_WJetMet) > 2. && abs(deltaPhi_WJetWlep) > 2. && MWW > 900. ";
+	// string TTBarEnrichedInclusive = "(jet_pt > 200.  &&  jet_tau21_PUPPI < 0.6  && Mjpruned < 200. && Mjpruned > 40. && W_pt > 200.  && abs(deltaR_LeptonWJet) > pi/2. && abs(deltaPhi_WJetMet) > 2. && abs(deltaPhi_WJetWlep) > 2. && MWW > 900. ";
+	string TTBarEnrichedInclusive = "(jet_pt > 200.  &&  jet_tau21_PUPPI < 0.55  && jet_mass_softdrop_PUPPI < 200. && jet_mass_softdrop_PUPPI > 40. && W_pt > 200.  && abs(deltaR_LeptonWJet) > pi/2. && abs(deltaPhi_WJetMet) > 2. && abs(deltaPhi_WJetWlep) > 2. && MWW > 900. ";
 	if (channel == "ele") TTBarEnrichedInclusive += " && l_pt > 50. && pfMET > 80. )"; 
 	else if (channel == "mu") TTBarEnrichedInclusive += " && l_pt > 50. && pfMET > 40. )"; 
 	else {
@@ -219,8 +229,8 @@ void draw(std::string channel, std::string region, std::string tag, string prefi
 		exit(0);
 	}
 
-	// string TTBarEnrichedBTagVeto = "(jet_pt > 200.  &&  jet_tau2tau1 < 0.6  && Mjpruned < 200. && Mjpruned > 40. && W_pt > 200.  && abs(deltaR_LeptonWJet) > pi/2. && abs(deltaPhi_WJetMet) > 2. && abs(deltaPhi_WJetWlep) > 2. && MWW > 900. && nbtag == 0 ";
-	string TTBarEnrichedBTagVeto = "(jet_pt > 200.  &&  jet_tau2tau1 < 0.55  && jet_mass_softdrop_PUPPI < 200. && jet_mass_softdrop_PUPPI > 40. && W_pt > 200.  && abs(deltaR_LeptonWJet) > pi/2. && abs(deltaPhi_WJetMet) > 2. && abs(deltaPhi_WJetWlep) > 2. && MWW > 900. && nbtag == 0 ";
+	// string TTBarEnrichedBTagVeto = "(jet_pt > 200.  &&  jet_tau21_PUPPI < 0.6  && Mjpruned < 200. && Mjpruned > 40. && W_pt > 200.  && abs(deltaR_LeptonWJet) > pi/2. && abs(deltaPhi_WJetMet) > 2. && abs(deltaPhi_WJetWlep) > 2. && MWW > 900. && nbtag == 0 ";
+	string TTBarEnrichedBTagVeto = "(jet_pt > 200.  &&  jet_tau21_PUPPI < 0.55  && jet_mass_softdrop_PUPPI < 200. && jet_mass_softdrop_PUPPI > 40. && W_pt > 200.  && abs(deltaR_LeptonWJet) > pi/2. && abs(deltaPhi_WJetMet) > 2. && abs(deltaPhi_WJetWlep) > 2. && MWW > 900. && nbtag == 0 ";
 	if (channel == "ele") TTBarEnrichedBTagVeto += " && l_pt > 50. && pfMET > 80. )"; 
 	else if (channel == "mu") TTBarEnrichedBTagVeto += " && l_pt > 50. && pfMET > 40. )"; 
 	else {

--- a/Common/test/addExtendedStats.sh
+++ b/Common/test/addExtendedStats.sh
@@ -7,14 +7,14 @@ cpCmd=scp
 
 echo "Processing Muon Channel"
 echo "ttbar";$cpCmd $sourceDir"ttbar_mu.root" .
-hadd WJets_Ht100To200_mu.root $sourceDir"WJets_Ht100To200_mu.root" $sourceDir"WJets_Ht100To200-ext1_mu.root" $sourceDir"WJets_Ht100To200-ext2_mu.root"
-hadd WJets_Ht200To400_mu.root $sourceDir"WJets_Ht200To400_mu.root" $sourceDir"WJets_Ht200To400-ext1_mu.root" $sourceDir"WJets_Ht200To400-ext2_mu.root"
-hadd WJets_Ht400To600_mu.root $sourceDir"WJets_Ht400To600_mu.root" $sourceDir"WJets_Ht400To600-ext_mu.root"
-hadd WJets_Ht600To800_mu.root $sourceDir"WJets_Ht600To800_mu.root" $sourceDir"WJets_Ht600To800-ext_mu.root"
-hadd WJets_Ht800To1200_mu.root $sourceDir"WJets_Ht800To1200_mu.root" $sourceDir"WJets_Ht800To1200-ext_mu.root"
-hadd WJets_Ht1200To2500_mu.root $sourceDir"WJets_Ht1200To2500_mu.root" $sourceDir"WJets_Ht1200To2500-ext_mu.root"
-hadd WJets_Ht2500ToInf_mu.root $sourceDir"WJets_Ht2500ToInf_mu.root" $sourceDir"WJets_Ht2500ToInf-ext_mu.root"
-hadd WW_mu.root $sourceDir"WW_mu.root" $sourceDir"WW-ext_mu.root"
+echo "WJets_Ht100To200";hadd WJets_Ht100To200_mu.root $sourceDir"WJets_Ht100To200_mu.root" $sourceDir"WJets_Ht100To200-ext1_mu.root" $sourceDir"WJets_Ht100To200-ext2_mu.root"
+echo "WJets_Ht200To400";hadd WJets_Ht200To400_mu.root $sourceDir"WJets_Ht200To400_mu.root" $sourceDir"WJets_Ht200To400-ext1_mu.root" $sourceDir"WJets_Ht200To400-ext2_mu.root"
+echo "WJets_Ht400To600";hadd WJets_Ht400To600_mu.root $sourceDir"WJets_Ht400To600_mu.root" $sourceDir"WJets_Ht400To600-ext_mu.root"
+echo "WJets_Ht600To800";hadd WJets_Ht600To800_mu.root $sourceDir"WJets_Ht600To800_mu.root" $sourceDir"WJets_Ht600To800-ext_mu.root"
+echo "WJets_Ht800To1200";hadd WJets_Ht800To1200_mu.root $sourceDir"WJets_Ht800To1200_mu.root" $sourceDir"WJets_Ht800To1200-ext_mu.root"
+echo "WJets_Ht1200To2500";hadd WJets_Ht1200To2500_mu.root $sourceDir"WJets_Ht1200To2500_mu.root" $sourceDir"WJets_Ht1200To2500-ext_mu.root"
+echo "WJets_Ht2500ToInf";hadd WJets_Ht2500ToInf_mu.root $sourceDir"WJets_Ht2500ToInf_mu.root" $sourceDir"WJets_Ht2500ToInf-ext_mu.root"
+echo "WW";hadd WW_mu.root $sourceDir"WW_mu.root" $sourceDir"WW-ext_mu.root"
 echo "WZ";$cpCmd $sourceDir"WZ_mu.root" .
 echo "t-top"; $cpCmd $sourceDir"t-ch-top_mu.root" .
 echo "t-antitop"; $cpCmd $sourceDir"t-ch-antitop_mu.root" .
@@ -25,18 +25,18 @@ echo "WW-aTGC_MWW-600To800";$cpCmd $sourceDir"WW-aTGC_MWW-600To800_mu.root" .
 echo "WW-aTGC_MWW-800ToInf";$cpCmd $sourceDir"WW-aTGC_MWW-800ToInf_mu.root" .
 echo "WZ-aTGC_MWZ-600To800";$cpCmd $sourceDir"WZ-aTGC_MWZ-600To800_mu.root" .
 echo "WZ-aTGC_MWZ-800ToInf";$cpCmd $sourceDir"WZ-aTGC_MWZ-800ToInf_mu.root" .
-hadd data_mu.root $sourceDir"data-RunB_ver2_mu.root" $sourceDir"data-RunC_mu.root" $sourceDir"data-RunD_mu.root" $sourceDir"data-RunE_mu.root" $sourceDir"data-RunF_mu.root" $sourceDir"data-RunG_mu.root" $sourceDir"data-RunH_ver2_mu.root" $sourceDir"data-RunH_ver3_mu.root"
+echo "data";hadd data_mu.root $sourceDir"data-RunB_ver2_mu.root" $sourceDir"data-RunC_mu.root" $sourceDir"data-RunD_mu.root" $sourceDir"data-RunE_mu.root" $sourceDir"data-RunF_mu.root" $sourceDir"data-RunG_mu.root" $sourceDir"data-RunH_ver2_mu.root" $sourceDir"data-RunH_ver3_mu.root"
 
 echo "Processing Electron Channel"
 echo "ttbar";$cpCmd $sourceDir"ttbar_ele.root" .
-hadd WJets_Ht100To200_ele.root $sourceDir"WJets_Ht100To200_ele.root" $sourceDir"WJets_Ht100To200-ext1_ele.root" $sourceDir"WJets_Ht100To200-ext2_ele.root"
-hadd WJets_Ht200To400_ele.root $sourceDir"WJets_Ht200To400_ele.root" $sourceDir"WJets_Ht200To400-ext1_ele.root" $sourceDir"WJets_Ht200To400-ext2_ele.root"
-hadd WJets_Ht400To600_ele.root $sourceDir"WJets_Ht400To600_ele.root" $sourceDir"WJets_Ht400To600-ext_ele.root"
-hadd WJets_Ht600To800_ele.root $sourceDir"WJets_Ht600To800_ele.root" $sourceDir"WJets_Ht600To800-ext_ele.root"
-hadd WJets_Ht800To1200_ele.root $sourceDir"WJets_Ht800To1200_ele.root" $sourceDir"WJets_Ht800To1200-ext_ele.root"
-hadd WJets_Ht1200To2500_ele.root $sourceDir"WJets_Ht1200To2500_ele.root" $sourceDir"WJets_Ht1200To2500-ext_ele.root"
-hadd WJets_Ht2500ToInf_ele.root $sourceDir"WJets_Ht2500ToInf_ele.root" $sourceDir"WJets_Ht2500ToInf-ext_ele.root"
-hadd WW_ele.root $sourceDir"WW_ele.root" $sourceDir"WW-ext_ele.root"
+echo "WJets_Ht100To200";hadd WJets_Ht100To200_ele.root $sourceDir"WJets_Ht100To200_ele.root" $sourceDir"WJets_Ht100To200-ext1_ele.root" $sourceDir"WJets_Ht100To200-ext2_ele.root"
+echo "WJets_Ht200To400";hadd WJets_Ht200To400_ele.root $sourceDir"WJets_Ht200To400_ele.root" $sourceDir"WJets_Ht200To400-ext1_ele.root" $sourceDir"WJets_Ht200To400-ext2_ele.root"
+echo "WJets_Ht400To600";hadd WJets_Ht400To600_ele.root $sourceDir"WJets_Ht400To600_ele.root" $sourceDir"WJets_Ht400To600-ext_ele.root"
+echo "WJets_Ht600To800";hadd WJets_Ht600To800_ele.root $sourceDir"WJets_Ht600To800_ele.root" $sourceDir"WJets_Ht600To800-ext_ele.root"
+echo "WJets_Ht800To1200";hadd WJets_Ht800To1200_ele.root $sourceDir"WJets_Ht800To1200_ele.root" $sourceDir"WJets_Ht800To1200-ext_ele.root"
+echo "WJets_Ht1200To2500";hadd WJets_Ht1200To2500_ele.root $sourceDir"WJets_Ht1200To2500_ele.root" $sourceDir"WJets_Ht1200To2500-ext_ele.root"
+echo "WJets_Ht2500ToInf";hadd WJets_Ht2500ToInf_ele.root $sourceDir"WJets_Ht2500ToInf_ele.root" $sourceDir"WJets_Ht2500ToInf-ext_ele.root"
+echo "WW";hadd WW_ele.root $sourceDir"WW_ele.root" $sourceDir"WW-ext_ele.root"
 echo "WZ";$cpCmd $sourceDir"WZ_ele.root" .
 echo "t-top";$cpCmd $sourceDir"t-ch-top_ele.root" .
 echo "t-antitop";$cpCmd $sourceDir"t-ch-antitop_ele.root" .
@@ -47,4 +47,4 @@ echo "WW-aTGC_MWW-600To800";$cpCmd $sourceDir"WW-aTGC_MWW-600To800_ele.root" .
 echo "WW-aTGC_MWW-800ToInf";$cpCmd $sourceDir"WW-aTGC_MWW-800ToInf_ele.root" .
 echo "WZ-aTGC_MWZ-600To800";$cpCmd $sourceDir"WZ-aTGC_MWZ-600To800_ele.root" .
 echo "WZ-aTGC_MWZ-800ToInf";$cpCmd $sourceDir"WZ-aTGC_MWZ-800ToInf_ele.root" .
-hadd data_ele.root $sourceDir"data-RunB_ver2_ele.root" $sourceDir"data-RunC_ele.root" $sourceDir"data-RunD_ele.root" $sourceDir"data-RunE_ele.root" $sourceDir"data-RunF_ele.root" $sourceDir"data-RunG_ele.root" $sourceDir"data-RunH_ver2_ele.root" $sourceDir"data-RunH_ver3_ele.root"
+echo "data";hadd data_ele.root $sourceDir"data-RunB_ver2_ele.root" $sourceDir"data-RunC_ele.root" $sourceDir"data-RunD_ele.root" $sourceDir"data-RunE_ele.root" $sourceDir"data-RunF_ele.root" $sourceDir"data-RunG_ele.root" $sourceDir"data-RunH_ver2_ele.root" $sourceDir"data-RunH_ver3_ele.root"

--- a/TreeMaker/plugins/TreeMaker.cc
+++ b/TreeMaker/plugins/TreeMaker.cc
@@ -137,7 +137,7 @@ private:
   int NAK8jet, njets, nbtag;
   double jet_pt, jet_eta, jet_phi, jet_mass, jet_mass_pruned, jet_mass_softdrop, jet_tau2tau1, jet_tau3tau2, jet_tau1, jet_tau2, jet_tau3;
   //PUPPI variables 
-  double jet_pt_PUPPI, jet_eta_PUPPI, jet_phi_PUPPI, jet_mass_PUPPI, jet_tau1_PUPPI, jet_tau2_PUPPI, jet_tau3_PUPPI, jet_tau21_PUPPI, jet_mass_softdrop_PUPPI, jet_tau21_DT;
+  double jet_pt_PUPPI, jet_eta_PUPPI, jet_phi_PUPPI, jet_mass_PUPPI, jet_tau1_PUPPI, jet_tau2_PUPPI, jet_tau3_PUPPI, jet_tau21_PUPPI, jet_tau32_PUPPI, jet_mass_softdrop_PUPPI, jet_tau21_DT;
 
   //gen info
   bool isMatched_;
@@ -531,6 +531,7 @@ TreeMaker::TreeMaker(const edm::ParameterSet& iConfig):
   outTree_->Branch("jet_tau2_PUPPI",    &jet_tau2_PUPPI,    "jet_tau2_PUPPI/D"   );
   outTree_->Branch("jet_tau3_PUPPI",    &jet_tau3_PUPPI,    "jet_tau3_PUPPI/D"   );
   outTree_->Branch("jet_tau21_PUPPI",    &jet_tau21_PUPPI,    "jet_tau21_PUPPI/D"   );
+  outTree_->Branch("jet_tau32_PUPPI",    &jet_tau32_PUPPI,    "jet_tau32_PUPPI/D"   );
   outTree_->Branch("jet_mass_softdrop_PUPPI",    &jet_mass_softdrop_PUPPI,    "jet_mass_softdrop_PUPPI/D"   );
   outTree_->Branch("jet_tau21_DT",    &jet_tau21_DT,    "jet_tau21_DT/D"   );
   
@@ -1188,6 +1189,7 @@ TreeMaker::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
     jet_tau2_PUPPI = fatJet.userFloat("ak8PFJetsPuppiValueMap:NjettinessAK8PuppiTau2");
     jet_tau3_PUPPI = fatJet.userFloat("ak8PFJetsPuppiValueMap:NjettinessAK8PuppiTau3");
     jet_tau21_PUPPI = jet_tau2_PUPPI/jet_tau1_PUPPI;
+    jet_tau32_PUPPI = jet_tau3_PUPPI/jet_tau2_PUPPI;
 
 
     TLorentzVector puppi_softdrop,puppi_softdrop_subjet;


### PR DESCRIPTION
Some updates/fixes to the AK8 jet:

- enable L1FastJet corrections. Due to some dodgy wording in https://github.com/cms-jet/PuppiSoftdropMassCorr/ I thought only L2L3 corrections were needed, but checking with Andreas it turns out that for **CHS** jets you **do** need L1 corrections.

- I also moved to cutting & plotting tau_21 from the associated PUPPI jet, not the CHS version of the variable, as it should be a better description (and is correct for the chosen cut value & VTagSF)

- I have also added in the PUPPI tau_32 var & a plot for interest.

- Since out data/MC is now better, I have shrunken the ratio plot range 😄 

(also added some more stuff to .gitignore that has been clogging up my git status...)