### PR TITLE
Update electron triggers as in B2G-16-029, apply trigger data efficiency to MC

### DIFF
--- a/Common/python/trigger_cff.py
+++ b/Common/python/trigger_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 TriggerMuon = cms.EDFilter("HLTHighLevel",
-				  HLTPaths = cms.vstring("HLT_Mu50_v*", "HLT_TkMu50_v*", "HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"),
+				  HLTPaths = cms.vstring("HLT_Mu50_v*", "HLT_TkMu50_v*"),
 				  throw = cms.bool(False),
 				  TriggerResultsTag = cms.InputTag("TriggerResults", "", "HLT"),
 				  andOr = cms.bool(True), eventSetupPathsKey = cms.string("")#false = and-mode (all requested triggers), true = or-mode (at least one) 

--- a/Common/python/trigger_cff.py
+++ b/Common/python/trigger_cff.py
@@ -1,15 +1,14 @@
 import FWCore.ParameterSet.Config as cms
 
 TriggerMuon = cms.EDFilter("HLTHighLevel",
-				  HLTPaths = cms.vstring("HLT_Mu50_v*", "HLT_TkMu50_v*"),
+				  HLTPaths = cms.vstring("HLT_Mu50_v*", "HLT_TkMu50_v*", "HLT_PFMETNoMu120_PFMHTNoMu120_IDTight_v*"),
 				  throw = cms.bool(False),
 				  TriggerResultsTag = cms.InputTag("TriggerResults", "", "HLT"),
 				  andOr = cms.bool(True), eventSetupPathsKey = cms.string("")#false = and-mode (all requested triggers), true = or-mode (at least one) 
 				 )
 
-# electron trigger is disables
 TriggerElectron = cms.EDFilter("HLTHighLevel",
-				  HLTPaths = cms.vstring("HLT_Ele45_WPLoose_Gsf_v*", "HLT_Ele105_CaloIdVT_GsfTrkIdT_v*", "HLT_Ele115_CaloIdVT_GsfTrkIdT_v*", "HLT_Ele30_WPTight_Gsf_v*", "HLT_Ele50_CaloIdVT_GsfTrkIdT_PFJet165_v*", "HLT_Ele27_WPLoose_Gsf_v*"),
+				  HLTPaths = cms.vstring("HLT_Ele45_WPLoose_Gsf_v*", "HLT_Ele115_CaloIdVT_GsfTrkIdT_v*", "HLT_Ele27_WPTight_Gsf_v*", "HLT_Photon175_v*"),
 				  throw = cms.bool(False),
 				  TriggerResultsTag = cms.InputTag("TriggerResults", "", "HLT"),
 				  andOr = cms.bool(True), eventSetupPathsKey = cms.string("")#false = and-mode (all requested triggers), true = or-mode (at least one) 

--- a/Common/test/Plotting/draw.cpp
+++ b/Common/test/Plotting/draw.cpp
@@ -255,40 +255,47 @@ void draw(std::string channel, std::string region, std::string tag, string prefi
 
 	std::string MCSelection,SignalSelection,DataSelection;
 
+	// Apply trigger bit requirement
+	if (channel == "ele") {
+		DataSelection = "bit_HLT_Ele_27_OR_45_OR_115 && ";
+	} else {
+		DataSelection = "";
+	}
+
 	if (region == "WJets"){
 		MCSelection =  addOnCutWjets ;
 		SignalSelection = "( " + addOnCutWjets + " )";
-		DataSelection = addOnCutWjets;
+		DataSelection += addOnCutWjets;
 	}
 	else if(region == "ttbar"){
 		MCSelection =  addOnCutTtbar;
 		SignalSelection = "( " + addOnCutTtbar + " )";
-		DataSelection = addOnCutTtbar;
+		DataSelection += addOnCutTtbar;
 	}
 	else if(region == "TTBarEnrichedInclusive"){
 		MCSelection =  TTBarEnrichedInclusive;
 		SignalSelection = "( " + TTBarEnrichedInclusive + " )";
-		DataSelection = TTBarEnrichedInclusive;
+		DataSelection += TTBarEnrichedInclusive;
 	}
 	else if(region == "TTBarEnrichedBTagVeto"){
 		MCSelection =  TTBarEnrichedBTagVeto;
 		SignalSelection = "( " + TTBarEnrichedBTagVeto + " )";
-		DataSelection = TTBarEnrichedBTagVeto;
+		DataSelection += TTBarEnrichedBTagVeto;
 	}
 	else if(region == "signal"){
 		MCSelection =  signalRegion;
 		SignalSelection = "( " + signalRegion + " )";
-		DataSelection = signalRegion;
+		DataSelection += signalRegion;
 	}
 	else if(region == "signalWW"){
                 MCSelection =  signalWWRegion;
                 SignalSelection = "( " + signalWWRegion + " )";
-                DataSelection = signalWWRegion;
+                DataSelection += signalWWRegion;
         }
 	else if(region == "signalWZ"){
                 MCSelection =  signalWZRegion;
                 SignalSelection = "( " + signalWZRegion + " )";
-                DataSelection = signalWZRegion;
+                DataSelection += signalWZRegion;
         }
 	else std::cout << "This should not happen ..." << std::endl;
 

--- a/Common/test/addWeightSamples.cpp
+++ b/Common/test/addWeightSamples.cpp
@@ -40,7 +40,7 @@ void addWeight(string FileName, float xsection, float lumi, std::string channel)
   double Nevents_ = Nevents(FileName);
   TFile file(FileName.c_str(), "UPDATE");
   TTree * tree = (TTree*) file.Get("treeDumper/BasicTree");
-  double totWeight, topPtSF, btagWeight, totWeight_BTagUp, totWeight_BTagDown, totWeight_MistagUp, totWeight_MistagDown, totWeight_LeptonIDUp, totWeight_LeptonIDDown, triggerWeightHLTEle27NoER;
+  double totWeight, topPtSF, btagWeight, totWeight_BTagUp, totWeight_BTagDown, totWeight_MistagUp, totWeight_MistagDown, totWeight_LeptonIDUp, totWeight_LeptonIDDown;
   tree -> SetBranchAddress("totWeight", &totWeight);
   tree -> SetBranchAddress("topPtSF", &topPtSF);
   tree -> SetBranchAddress("btagWeight", &btagWeight);
@@ -50,7 +50,6 @@ void addWeight(string FileName, float xsection, float lumi, std::string channel)
   tree -> SetBranchAddress("totWeight_MistagDown", &totWeight_MistagDown);
   tree -> SetBranchAddress("totWeight_LeptonIDUp", &totWeight_LeptonIDUp);
   tree -> SetBranchAddress("totWeight_LeptonIDDown", &totWeight_LeptonIDDown);
-  if (channel == "ele") tree -> SetBranchAddress("triggerWeightHLTEle27NoER", &triggerWeightHLTEle27NoER);
   double totWeightWithLumi, totWeightWithLumiNoBtag, totWeightWithLumi_MistagUp, totWeightWithLumi_MistagDown, totWeightWithLumi_BTagUp, totWeightWithLumi_BTagDown, totWeightWithLumi_LeptonIDUp, totWeightWithLumi_LeptonIDDown;
   TBranch * br = tree -> Branch("totEventWeight", &totWeightWithLumi, "totEventWeight/D"); 
   TBranch * br_NoBtag = tree -> Branch("totEventWeightNoBtag", &totWeightWithLumiNoBtag, "totEventWeightNoBtag/D");
@@ -76,23 +75,14 @@ void addWeight(string FileName, float xsection, float lumi, std::string channel)
   for (unsigned int iEntry = 0; iEntry < tree -> GetEntries(); iEntry ++)
   {
     tree -> GetEntry(iEntry); 
-    // if (channel == "ele"){
-    //   totWeightWithLumi = totWeight*weightLumi/triggerWeightHLTEle27NoER;
-    //   totWeightWithLumi_BTagUp = totWeight_BTagUp*weightLumi/triggerWeightHLTEle27NoER;
-    //   totWeightWithLumi_BTagDown = totWeight_BTagDown*weightLumi/triggerWeightHLTEle27NoER;
-    //   totWeightWithLumi_MistagUp= totWeight_MistagUp*weightLumi/triggerWeightHLTEle27NoER;
-    //   totWeightWithLumi_MistagDown = totWeight_MistagDown*weightLumi/triggerWeightHLTEle27NoER;
-    // }
-    // else { 
-      totWeightWithLumi = totWeight*weightLumi;
-      totWeightWithLumiNoBtag = totWeightWithLumi/btagWeight;
-      totWeightWithLumi_BTagUp = totWeight_BTagUp*weightLumi;
-      totWeightWithLumi_BTagDown = totWeight_BTagDown*weightLumi;
-      totWeightWithLumi_MistagUp= totWeight_MistagUp*weightLumi;
-      totWeightWithLumi_MistagDown = totWeight_MistagDown*weightLumi;
-      totWeightWithLumi_LeptonIDUp= totWeight_LeptonIDUp*weightLumi;
-      totWeightWithLumi_LeptonIDDown = totWeight_LeptonIDDown*weightLumi;
-    // }
+    totWeightWithLumi = totWeight*weightLumi;
+    totWeightWithLumiNoBtag = totWeightWithLumi/btagWeight;
+    totWeightWithLumi_BTagUp = totWeight_BTagUp*weightLumi;
+    totWeightWithLumi_BTagDown = totWeight_BTagDown*weightLumi;
+    totWeightWithLumi_MistagUp= totWeight_MistagUp*weightLumi;
+    totWeightWithLumi_MistagDown = totWeight_MistagDown*weightLumi;
+    totWeightWithLumi_LeptonIDUp= totWeight_LeptonIDUp*weightLumi;
+    totWeightWithLumi_LeptonIDDown = totWeight_LeptonIDDown*weightLumi;
     br -> Fill();
     br_NoBtag -> Fill();
     br_MistagUp -> Fill();

--- a/Common/test/addWeightSamples.cpp
+++ b/Common/test/addWeightSamples.cpp
@@ -11,7 +11,8 @@
 #include <TLegend.h>
 #include <TDirectoryFile.h>
 #include <iostream>
-#include <iostream>
+
+#include "../../TreeMaker/plugins/EleTriggerEff.h"
 
 
 /*
@@ -35,6 +36,21 @@ double Nevents(std::string filename){
   }
   return sum;
 }
+
+
+float getElectronTriggerEff(TH2F * eleDataTriggerEffMap, float pt, float eta) {
+  eta = fabs(eta);
+  int etaBin = eleDataTriggerEffMap->GetXaxis()->FindBin(eta);
+
+  // If we have too high pT, assume its the same as the last pt bin
+  if (pt > eleDataTriggerEffMap->GetYaxis()->GetBinLowEdge(eleDataTriggerEffMap->GetNbinsY()+1)) {
+    pt = eleDataTriggerEffMap->GetYaxis()->GetBinLowEdge(eleDataTriggerEffMap->GetNbinsY()+1) - 0.1;
+  }
+  int ptBin = eleDataTriggerEffMap->GetYaxis()->FindBin(pt);
+  return eleDataTriggerEffMap->GetBinContent(etaBin, ptBin);
+}
+
+
 void addWeight(string FileName, float xsection, float lumi, std::string channel)
 {
   double Nevents_ = Nevents(FileName);
@@ -50,6 +66,12 @@ void addWeight(string FileName, float xsection, float lumi, std::string channel)
   tree -> SetBranchAddress("totWeight_MistagDown", &totWeight_MistagDown);
   tree -> SetBranchAddress("totWeight_LeptonIDUp", &totWeight_LeptonIDUp);
   tree -> SetBranchAddress("totWeight_LeptonIDDown", &totWeight_LeptonIDDown);
+  double l_pt, l_eta;
+  if (channel == "ele"){
+    tree -> SetBranchAddress("l_pt", &l_pt);
+    tree -> SetBranchAddress("l_eta", &l_eta);
+  } 
+
   double totWeightWithLumi, totWeightWithLumiNoBtag, totWeightWithLumi_MistagUp, totWeightWithLumi_MistagDown, totWeightWithLumi_BTagUp, totWeightWithLumi_BTagDown, totWeightWithLumi_LeptonIDUp, totWeightWithLumi_LeptonIDDown;
   TBranch * br = tree -> Branch("totEventWeight", &totWeightWithLumi, "totEventWeight/D"); 
   TBranch * br_NoBtag = tree -> Branch("totEventWeightNoBtag", &totWeightWithLumiNoBtag, "totEventWeightNoBtag/D");
@@ -61,6 +83,14 @@ void addWeight(string FileName, float xsection, float lumi, std::string channel)
   TBranch * br_LeptonIDDown = tree -> Branch("totEventWeight_LeptonIDDown", &totWeightWithLumi_LeptonIDDown, "totEventWeight_LeptonIDDown/D");
   std::cout << FileName << std::endl;
   std::cout << "Number of events (effective):" << Nevents_ << std::endl;
+
+  TH2F * eleDataTriggerEffMap;
+  if (channel == "ele"){
+    eleDataTriggerEffMap = electron_data_eff();
+    if (eleDataTriggerEffMap == nullptr) {
+      throw std::runtime_error("Cannot get electron trigger efficiency map");
+    }
+  }
 
   // Calculate mean top Pt SF first
   double meanTopWeight = 0.;
@@ -75,7 +105,13 @@ void addWeight(string FileName, float xsection, float lumi, std::string channel)
   for (unsigned int iEntry = 0; iEntry < tree -> GetEntries(); iEntry ++)
   {
     tree -> GetEntry(iEntry); 
-    totWeightWithLumi = totWeight*weightLumi;
+
+    float eleTrigEff = 1;
+    if (channel == "ele") {
+      eleTrigEff = getElectronTriggerEff(eleDataTriggerEffMap, l_pt, l_eta);
+    }
+
+    totWeightWithLumi = totWeight*weightLumi*eleTrigEff;
     totWeightWithLumiNoBtag = totWeightWithLumi/btagWeight;
     totWeightWithLumi_BTagUp = totWeight_BTagUp*weightLumi;
     totWeightWithLumi_BTagDown = totWeight_BTagDown*weightLumi;

--- a/TreeMaker/plugins/EleTriggerEff.h
+++ b/TreeMaker/plugins/EleTriggerEff.h
@@ -12,7 +12,7 @@ using std::vector;
 // Store the combined electron trigger efficiencies for MC & Data
 // This is taken from B2G-16-029 but their "orthogonal method" plots in backup of preapproval:
 // https://indico.cern.ch/event/616149/contributions/2486779/attachments/1418259/2172181/preapproval_B2G-16-029_Huang_Huang_20170224.pdf
-// And is only applicable for the combo 
+// And is only applicable for the combo
 // HLT_Ele45_WPLoose_Gsf_v* OR HLT_Ele115_CaloIdVT_GsfTrkIdT_v* OR HLT_Ele27_WPTight_Gsf_v*
 // Their main trigger eff plots are for only Ele115
 
@@ -66,7 +66,7 @@ TH2F * electron_data_eff() {
   TH2F * mapEleEffData = new TH2F("mapEleEffData", "Electron trigger efficiency (data);|#eta^{e}|;p_{T}^{e} [GeV]", etaBins.size()-1, &etaBins[0], ptBins.size()-1, &ptBins[0]);
   if (data_eff.size() != ptBins.size()-1) throw std::runtime_error("Wrong pt size");
   if (data_eff_err.size() != ptBins.size()-1) throw std::runtime_error("Wrong pt size");
-  
+
   for (uint ptInd=0; ptInd<ptBins.size()-1; ptInd++) {
     if (data_eff.at(ptInd).size() != etaBins.size()-1) throw std::runtime_error("Wrong eta size");
     if (data_eff_err.at(ptInd).size() != etaBins.size()-1) throw std::runtime_error("Wrong eta size");

--- a/TreeMaker/plugins/EleTriggerEff.h
+++ b/TreeMaker/plugins/EleTriggerEff.h
@@ -1,0 +1,99 @@
+#ifndef ELETRIGGEREFF_H
+#define ELETRIGGEREFF_H
+
+#include <vector>
+#include <exception>
+
+#include "TH2.h"
+#include "TCanvas.h"
+
+using std::vector;
+
+// Store the combined electron trigger efficiencies for MC & Data
+// This is taken from B2G-16-029 but their "orthogonal method" plots in backup of preapproval:
+// https://indico.cern.ch/event/616149/contributions/2486779/attachments/1418259/2172181/preapproval_B2G-16-029_Huang_Huang_20170224.pdf
+// And is only applicable for the combo 
+// HLT_Ele45_WPLoose_Gsf_v* OR HLT_Ele115_CaloIdVT_GsfTrkIdT_v* OR HLT_Ele27_WPTight_Gsf_v*
+// Their main trigger eff plots are for only Ele115
+
+const static vector<float> ptBins = {45, 50, 55, 70, 100, 120, 180, 250, 1000};
+const static vector<float> etaBins = {0, 0.8, 1.44, 1.566, 2, 2.4};
+
+const static vector<vector<float>> data_eff = {
+  {0.780594, 0.799735, 0.75, 0.679181, 0.574766}, // pt=45 to 50
+  {0.825967, 0.833597, 0.916667, 0.757463, 0.593407}, // pt=50 to 55
+  {0.866183, 0.856773, 0.714286, 0.739193, 0.698765},
+  {0.882139, 0.893051, 0.8, 0.789272, 0.700637},
+  {0.903775, 0.901726, 0.818182, 0.806897, 0.775862},
+  {0.961097, 0.966073, 1, 0.972678, 0.975248},
+  {0.959327, 0.968254, 1, 0.982906, 0.985294},
+  {0.953846, 0.955696, 1, 1, 0.964286}
+};
+const static vector<vector<float>> data_eff_err = {
+  {0.0122356, 0.0145744, 0.125, 0.0272702, 0.033795}, // pt=45 to 50
+  {0.0115049, 0.0148267, 0.0797856, 0.026182, 0.03641}, // pt=50 to 55
+  {0.00683513, 0.00891791, 0.0853735, 0.0166671, 0.0227977},
+  {0.00561985, 0.00686098, 0.0676123, 0.0145745, 0.0211026},
+  {0.00802318, 0.0108482, 0.116291, 0.0231795, 0.0316137},
+  {0.00431834, 0.00527255, 0, 0.00852125, 0.0109318},
+  {0.00739763, 0.00901765, 0, 0.0119835, 0.0145974},
+  {0.0116386, 0.0163701, 0, 0, 0.0350707}
+};
+
+const static vector<vector<float>> mc_eff = {
+  {0.812521, 0.805187, 0.83871, 0.792846, 0.721951},
+  {0.823198, 0.853138, 0.83871, 0.80602, 0.743961},
+  {0.864873, 0.878969, 0.821429, 0.849629, 0.784289},
+  {0.899037, 0.912407, 0.787234, 0.86172, 0.82563},
+  {0.936532, 0.943288, 0.857143, 0.890555, 0.909938},
+  {0.986214, 0.986737, 0.976744, 0.988249, 0.989924},
+  {0.985003, 0.989474, 0.989474, 0.983333, 0.981308},
+  {0.98951, 0.992857, 1, 1, 1}
+};
+
+const static vector<vector<float>> mc_eff_err = {
+  {0.00712223, 0.0095084, 0.0660586, 0.0156451, 0.0156451},
+  {0.00739143, 0.00873795, 0.0660586, 0.0161697, 0.0161697},
+  {0.00421471, 0.00526206, 0.041788, 0.00928167, 0.00928167},
+  {0.00328547, 0.00411706, 0.0422123, 0.00818417, 0.00818417},
+  {0.00420852, 0.00527572, 0.06613, 0.0120883, 0.0120883},
+  {0.00167258, 0.00222687, 0.0229838, 0.00369406, 0.00369406},
+  {0.00317322, 0.00370198, 0.0644061, 0.0082636, 0.0082636},
+  {0.00425981, 0.00503269, 0, 0, 0 }
+};
+
+TH2F * electron_data_eff() {
+  TH2F * mapEleEffData = new TH2F("mapEleEffData", "Electron trigger efficiency (data);|#eta^{e}|;p_{T}^{e} [GeV]", etaBins.size()-1, &etaBins[0], ptBins.size()-1, &ptBins[0]);
+  if (data_eff.size() != ptBins.size()-1) throw std::runtime_error("Wrong pt size");
+  if (data_eff_err.size() != ptBins.size()-1) throw std::runtime_error("Wrong pt size");
+  
+  for (uint ptInd=0; ptInd<ptBins.size()-1; ptInd++) {
+    if (data_eff.at(ptInd).size() != etaBins.size()-1) throw std::runtime_error("Wrong eta size");
+    if (data_eff_err.at(ptInd).size() != etaBins.size()-1) throw std::runtime_error("Wrong eta size");
+
+    for (uint etaInd=0; etaInd<etaBins.size()-1; etaInd++) {
+      mapEleEffData->SetBinContent(etaInd+1, ptInd+1, data_eff.at(ptInd).at(etaInd));
+      mapEleEffData->SetBinError(etaInd+1, ptInd+1, data_eff_err.at(ptInd).at(etaInd));
+    }
+  }
+  return mapEleEffData;
+}
+
+TH2F * electron_mc_eff() {
+  TH2F * mapEleEffMC = new TH2F("mapEleEffMC", "Electron trigger efficiency (MC);|#eta^{e}|;p_{T}^{e} [GeV]", etaBins.size()-1, &etaBins[0], ptBins.size()-1, &ptBins[0]);
+  if (mc_eff.size() != ptBins.size()-1) throw std::runtime_error("Wrong pt size");
+  if (mc_eff_err.size() != ptBins.size()-1) throw std::runtime_error("Wrong pt size");
+
+  for (uint ptInd=0; ptInd<ptBins.size()-1; ptInd++) {
+    if (mc_eff.at(ptInd).size() != etaBins.size()-1) throw std::runtime_error("Wrong eta size");
+    if (mc_eff_err.at(ptInd).size() != etaBins.size()-1) throw std::runtime_error("Wrong eta size");
+
+    for (uint etaInd=0; etaInd<etaBins.size()-1; etaInd++) {
+      mapEleEffMC->SetBinContent(etaInd+1, ptInd+1, mc_eff.at(ptInd).at(etaInd));
+      mapEleEffMC->SetBinError(etaInd+1, ptInd+1, mc_eff_err.at(ptInd).at(etaInd));
+    }
+  }
+  return mapEleEffMC;
+}
+
+#endif

--- a/TreeMaker/plugins/TreeMaker.cc
+++ b/TreeMaker/plugins/TreeMaker.cc
@@ -62,7 +62,7 @@
 #include "ScaleFactorHelper.h"
 #include "BTagHelper.h"
 #include "JetResolutionSmearer.h"
-#include "Ele27WPLooseTrigTurnOn.h"
+#include "EleTriggerEff.h"
 
 namespace reco {
   typedef edm::Ptr<reco::Muon> MuonPtr;
@@ -84,6 +84,8 @@ private:
   virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
   virtual void endRun(edm::Run const& iEvent, edm::EventSetup const&) override;
   virtual void endJob() override;
+
+  virtual float getElectronTriggerEff(float pt, float eta);
   virtual float getPUPPIweight(float, float); 
   virtual float getSmearingFactor(float sf, float unc, float resolution, const pat::Jet & jet, const edm::View<reco::GenJet> & genJets, int variation, float drMax, float relResMax, bool usePuppiPt);
   // we need all these 3 overloaded methods as we use different 4-vector classes
@@ -195,10 +197,11 @@ private:
 
   std::vector<double> PDFWeights;
   std::vector<double> ScaleWeights;
-  bool bit_HLT_Ele_105, bit_HLT_Ele_27, bit_HLT_Ele_45, bit_HLT_Ele_115, bit_HLT_Ele_30, bit_HLT_Ele_50_Jet_165, bit_BOTH_115_165;
-  double triggerWeightHLTEle27NoER;
-  
-  
+  bool bit_HLT_Ele_27_tight, bit_HLT_Ele_45, bit_HLT_Ele_115, bit_HLT_Photon_175, bit_HLT_Ele_27_OR_45_OR_115;
+  double eleTriggerWeight;
+
+  TH2F * eleDataTriggerEffMap;
+
   //Defining Tokens
   edm::EDGetTokenT<std::vector< PileupSummaryInfo > > PUInfoToken_;
   edm::EDGetTokenT<edm::View<pat::MET> > metToken_;
@@ -336,7 +339,6 @@ TreeMaker::TreeMaker(const edm::ParameterSet& iConfig):
      outTree_->Branch("LeptonSF_Down",       &LeptonSF_Down,     "LeptonSF_Down/D"          );
      outTree_->Branch("genweight",       &genWeight,     "genweight/D"          );
      outTree_->Branch("btagWeight",       &btagWeight,     "btagWeight/D"          );
-     if(channel == "el")outTree_->Branch("triggerWeightHLTEle27NoER",       &triggerWeightHLTEle27NoER,     "triggerWeightHLTEle27NoER/D"          );
      outTree_->Branch("btagWeight_BTagUp",       &btagWeight_BTagUp,     "btagWeight_BTagUp/D"          );
      outTree_->Branch("btagWeight_BTagDown",       &btagWeight_BTagDown,     "btagWeight_BTagDown/D"          );
      outTree_->Branch("btagWeight_MistagUp",       &btagWeight_MistagUp,     "btagWeight_MistagUp/D"          );
@@ -375,13 +377,13 @@ TreeMaker::TreeMaker(const edm::ParameterSet& iConfig):
      outTree_->Branch("genMWV", &genMWV, "genMWV/D");
    };
   if (channel == "el") {
-    outTree_->Branch("bit_HLT_Ele_105",       &bit_HLT_Ele_105,     "bit_HLT_Ele_105/B"          );
-    outTree_->Branch("bit_HLT_Ele_27",       &bit_HLT_Ele_27,     "bit_HLT_Ele_27/B"          );
+    outTree_->Branch("bit_HLT_Ele_27_tight",       &bit_HLT_Ele_27_tight,     "bit_HLT_Ele_27_tight/B"          );
     outTree_->Branch("bit_HLT_Ele_45",       &bit_HLT_Ele_45,     "bit_HLT_Ele_45/B"          );
     outTree_->Branch("bit_HLT_Ele_115",       &bit_HLT_Ele_115,     "bit_HLT_Ele_115/B"          );
-    outTree_->Branch("bit_HLT_Ele_30",       &bit_HLT_Ele_30,     "bit_HLT_Ele_30/B"          );
-    outTree_->Branch("bit_HLT_Ele_50_Jet_165",       &bit_HLT_Ele_50_Jet_165,     "bit_HLT_Ele_50_Jet_165/B"          );
-    outTree_->Branch("bit_BOTH_115_165",       &bit_BOTH_115_165,     "bit_BOTH_115_165/B"          );
+    outTree_->Branch("bit_HLT_Photon_175",       &bit_HLT_Photon_175,     "bit_HLT_Photon_175/B"          );
+    outTree_->Branch("bit_HLT_Ele_27_OR_45_OR_115",       &bit_HLT_Ele_27_OR_45_OR_115,     "bit_HLT_Ele_27_OR_45_OR_115/B");
+    outTree_->Branch("eleTriggerWeight",       &eleTriggerWeight,     "eleTriggerWeight/D");
+    eleDataTriggerEffMap = electron_data_eff();
   }
   
   //number of loose leptons
@@ -974,8 +976,6 @@ TreeMaker::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
       sc_et = (superCluster -> energy())* sin((aselectronPtr->superClusterPosition()).theta());
       const reco::CaloClusterPtr& seed = aselectronPtr -> superCluster()->seed();
       isEB = ( seed->seed().subdetId() == EcalBarrel );
-      triggerWeightHLTEle27NoER  =  trigEle27NoER::turnOn(sc_et, sc_eta);
-
     }
     if (isMC){
        Lepton.pt_LeptonEnUp = LeptonSystMap.at("LeptonEnUp").Pt();
@@ -1626,21 +1626,24 @@ TreeMaker::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
      }
    }
 
-   edm::Handle<edm::TriggerResults> Triggers;
-   if (channel == "el") {
-      iEvent.getByToken(TriggerResultsToken, Triggers); 
-      edm::TriggerNames names = iEvent.triggerNames(*Triggers);
-      for (unsigned int iTrig = 0; iTrig < Triggers -> size(); iTrig ++)
-      {
-        if( boost::algorithm::contains(names.triggerName(iTrig), "HLT_Ele105_CaloIdVT_GsfTrkIdT_v") ) bit_HLT_Ele_105 = Triggers -> accept(iTrig);
-        if( boost::algorithm::contains(names.triggerName(iTrig), "HLT_Ele27_WPLoose_Gsf_v") )  bit_HLT_Ele_27 =  Triggers -> accept(iTrig);
-	if( boost::algorithm::contains(names.triggerName(iTrig), "HLT_Ele45_WPLoose_Gsf_v") )  bit_HLT_Ele_45 =  Triggers -> accept(iTrig);
-	if( boost::algorithm::contains(names.triggerName(iTrig), "HLT_Ele115_CaloIdVT_GsfTrkIdT_v") )  bit_HLT_Ele_115 =  Triggers -> accept(iTrig);
-	if( boost::algorithm::contains(names.triggerName(iTrig), "HLT_Ele30_WPTight_Gsf_v") )  bit_HLT_Ele_30 =  Triggers -> accept(iTrig);
-	if( boost::algorithm::contains(names.triggerName(iTrig), "HLT_Ele50_CaloIdVT_GsfTrkIdT_PFJet165_v") )  bit_HLT_Ele_50_Jet_165 =  Triggers -> accept(iTrig);
-     }
-   }
-  if(bit_HLT_Ele_115 && bit_HLT_Ele_50_Jet_165) bit_BOTH_115_165 = 1;
+  edm::Handle<edm::TriggerResults> Triggers;
+  eleTriggerWeight = 1.;
+  if (channel == "el") {
+    iEvent.getByToken(TriggerResultsToken, Triggers);
+    edm::TriggerNames names = iEvent.triggerNames(*Triggers);
+    for (unsigned int iTrig = 0; iTrig < Triggers -> size(); iTrig ++)
+    {
+        if( boost::algorithm::contains(names.triggerName(iTrig), "HLT_Ele27_WPTight_Gsf_v") )  bit_HLT_Ele_27_tight =  Triggers -> accept(iTrig);
+        if( boost::algorithm::contains(names.triggerName(iTrig), "HLT_Ele45_WPLoose_Gsf_v") )  bit_HLT_Ele_45 =  Triggers -> accept(iTrig);
+        if( boost::algorithm::contains(names.triggerName(iTrig), "HLT_Ele115_CaloIdVT_GsfTrkIdT_v") )  bit_HLT_Ele_115 =  Triggers -> accept(iTrig);
+        if( boost::algorithm::contains(names.triggerName(iTrig), "HLT_Photon175_v") )  bit_HLT_Photon_175 =  Triggers -> accept(iTrig);
+        bit_HLT_Ele_27_OR_45_OR_115 = bit_HLT_Ele_27_tight || bit_HLT_Ele_45 || bit_HLT_Ele_115;
+    }
+    if (isMC) {
+      // store equivalent trigger efficiency in data for later weighting
+      eleTriggerWeight = getElectronTriggerEff(Lepton.pt, Lepton.eta);
+    }
+  }
 
   topPtSF=1.;
   bool topInGen=0, antitopInGen=0;
@@ -1667,22 +1670,14 @@ TreeMaker::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   if(isMC && !isSignal) genWeightPosForaTGC=genWeight;
 
   if (isMC) {
-    totWeight = PUweight*genWeightPosForaTGC*aTGCWeightUnitConv*LeptonSF*btagWeight*VTagSF*topPtSF;
-    totWeight_BTagUp = PUweight*genWeightPosForaTGC*aTGCWeightUnitConv*LeptonSF*btagWeight_BTagUp*VTagSF*topPtSF;
-    totWeight_BTagDown = PUweight*genWeightPosForaTGC*aTGCWeightUnitConv*LeptonSF*btagWeight_BTagDown*VTagSF*topPtSF;
-    totWeight_MistagUp = PUweight*genWeightPosForaTGC*aTGCWeightUnitConv*LeptonSF*btagWeight_MistagUp*VTagSF*topPtSF;
-    totWeight_MistagDown = PUweight*genWeightPosForaTGC*aTGCWeightUnitConv*LeptonSF*btagWeight_MistagDown*VTagSF*topPtSF;
-    totWeight_LeptonIDUp = PUweight*genWeightPosForaTGC*aTGCWeightUnitConv*LeptonSF_Up*btagWeight*VTagSF*topPtSF;
-    totWeight_LeptonIDDown = PUweight*genWeightPosForaTGC*aTGCWeightUnitConv*LeptonSF_Down*btagWeight*VTagSF*topPtSF;
+    totWeight = PUweight*genWeightPosForaTGC*aTGCWeightUnitConv*LeptonSF*btagWeight*VTagSF*topPtSF*eleTriggerWeight;
+    totWeight_BTagUp = PUweight*genWeightPosForaTGC*aTGCWeightUnitConv*LeptonSF*btagWeight_BTagUp*VTagSF*topPtSF*eleTriggerWeight;
+    totWeight_BTagDown = PUweight*genWeightPosForaTGC*aTGCWeightUnitConv*LeptonSF*btagWeight_BTagDown*VTagSF*topPtSF*eleTriggerWeight;
+    totWeight_MistagUp = PUweight*genWeightPosForaTGC*aTGCWeightUnitConv*LeptonSF*btagWeight_MistagUp*VTagSF*topPtSF*eleTriggerWeight;
+    totWeight_MistagDown = PUweight*genWeightPosForaTGC*aTGCWeightUnitConv*LeptonSF*btagWeight_MistagDown*VTagSF*topPtSF*eleTriggerWeight;
+    totWeight_LeptonIDUp = PUweight*genWeightPosForaTGC*aTGCWeightUnitConv*LeptonSF_Up*btagWeight*VTagSF*topPtSF*eleTriggerWeight;
+    totWeight_LeptonIDDown = PUweight*genWeightPosForaTGC*aTGCWeightUnitConv*LeptonSF_Down*btagWeight*VTagSF*topPtSF*eleTriggerWeight;
   }
-  //probably would leave it like that if we keep reweighting to data trigger efficiency in electron channel. In this case lepton ID & trigger scale factors are set to unity in the electron channel.
-  /*if (isMC&&channel=="el"){
-    totWeight *=  triggerWeightHLTEle27NoER;
-    totWeight_BTagUp *= triggerWeightHLTEle27NoER;
-    totWeight_BTagDown *= triggerWeightHLTEle27NoER;
-    totWeight_MistagUp *= triggerWeightHLTEle27NoER; 
-    totWeight_MistagDown *= triggerWeightHLTEle27NoER;
-  }*/
 
   if(isSignal)
   {
@@ -1693,6 +1688,19 @@ TreeMaker::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 	outTree_->Fill();
   }
 
+}
+
+
+float TreeMaker::getElectronTriggerEff(float pt, float eta) {
+  eta = fabs(eta);
+  int etaBin = eleDataTriggerEffMap->GetXaxis()->FindBin(eta);
+
+  // If we have too high pT, assume its the same as the last pt bin
+  if (pt > eleDataTriggerEffMap->GetYaxis()->GetBinLowEdge(eleDataTriggerEffMap->GetNbinsY()+1)) {
+    pt = eleDataTriggerEffMap->GetYaxis()->GetBinLowEdge(eleDataTriggerEffMap->GetNbinsY()+1) - 0.1;
+  }
+  int ptBin = eleDataTriggerEffMap->GetYaxis()->FindBin(pt);
+  return eleDataTriggerEffMap->GetBinContent(etaBin, ptBin);
 }
 
 float TreeMaker::getPUPPIweight(float puppipt, float puppieta){


### PR DESCRIPTION
Update to the same triggers they use in B2G-16-029, and added in their efficiency maps. 
I've also allowed OR with & stored the Photon175 trigger, just incase someone asks us to check it out as well. To that end, I've added in `bit_HLT_Ele_27_OR_45_OR_115` to store the OR of the 3 electron triggers, and added it into the cuts in `draw.cpp`.

To apply the data trigger efficiencies in MC, I've applied them in `addWeightSamples.cpp` (as the MC is produced without requiring any trigger)